### PR TITLE
Add save file restoring

### DIFF
--- a/arm9/source/date.cpp
+++ b/arm9/source/date.cpp
@@ -54,7 +54,7 @@ size_t GetDate(DateFormat format, char *buf, size_t size)
  * Get the current time formatted for the top bar.
  * @return std::string containing the time.
  */
-string RetTime()
+std::string RetTime()
 {
 	time_t Raw;
 	time(&Raw);
@@ -63,14 +63,14 @@ string RetTime()
 	char Tmp[8];
 	strftime(Tmp, sizeof(Tmp), "%k:%M", Time);
 
-	return string(Tmp);
+	return std::string(Tmp);
 }
 
 /**
  * Get the current time formatted for filenames.
  * @return std::string containing the time.
  */
-string RetTimeForFilename()
+std::string RetTimeForFilename()
 {
 	time_t Raw;
 	time(&Raw);
@@ -79,7 +79,7 @@ string RetTimeForFilename()
 	char Tmp[8];
 	strftime(Tmp, sizeof(Tmp), "%k%M%S", Time);
 
-	return string(Tmp);
+	return std::string(Tmp);
 }
 
 /**

--- a/arm9/source/driveMenu.cpp
+++ b/arm9/source/driveMenu.cpp
@@ -41,8 +41,6 @@
 
 #define sizeOfdmAssignedOp 8
 
-using namespace std;
-
 //static bool ramDumped = false;
 
 bool flashcardMountSkipped = true;

--- a/arm9/source/dumpOperations.h
+++ b/arm9/source/dumpOperations.h
@@ -1,7 +1,9 @@
 #ifndef DUMPING_H
 #define DUMPING_H
 
-extern void ndsCardDump(void);
-extern void gbaCartDump(void);
+void ndsCardSaveRestore(const char *filename);
+
+void ndsCardDump(void);
+void gbaCartDump(void);
 
 #endif //DUMPING_H

--- a/arm9/source/fileOperations.cpp
+++ b/arm9/source/fileOperations.cpp
@@ -8,15 +8,13 @@
 #include "date.h"
 #include "file_browse.h"
 
-using namespace std;
-
 #define copyBufSize 0x8000
 
 u32 copyBuf[copyBufSize];
 
 extern PrintConsole topConsole, bottomConsole;
 
-vector<ClipboardFile> clipboard;
+std::vector<ClipboardFile> clipboard;
 bool clipboardOn = false;
 bool clipboardUsed = false;
 
@@ -77,7 +75,7 @@ off_t getFileSize(const char *fileName)
 }
 
 void dirCopy(DirEntry* entry, int i, const char *destinationPath, const char *sourcePath) {
-	vector<DirEntry> dirContents;
+	std::vector<DirEntry> dirContents;
 	dirContents.clear();
 	if (entry->isDirectory)	chdir((sourcePath + ("/" + entry->name)).c_str());
 	getDirectoryContents(dirContents);
@@ -94,7 +92,7 @@ int fcopy(const char *sourcePath, const char *destinationPath)
 
 		// Source path is a directory
 		chdir(sourcePath);
-		vector<DirEntry> dirContents;
+		std::vector<DirEntry> dirContents;
 		getDirectoryContents(dirContents);
 		DirEntry* entry = NULL;
 

--- a/arm9/source/fileOperations.h
+++ b/arm9/source/fileOperations.h
@@ -15,7 +15,7 @@ struct ClipboardFile {
 	ClipboardFile(const char *path, const char *name, bool folder, int drive, bool nitro);
 };
 
-extern vector<ClipboardFile> clipboard;
+extern std::vector<ClipboardFile> clipboard;
 extern bool clipboardOn;
 extern bool clipboardUsed;
 

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -37,6 +37,7 @@
 #include "fileOperations.h"
 #include "driveMenu.h"
 #include "driveOperations.h"
+#include "dumpOperations.h"
 #include "nitrofs.h"
 
 #define SCREEN_COLS 22
@@ -182,9 +183,9 @@ void showDirectoryContents (const std::vector<DirEntry>& dirContents, int fileOf
 	printf ("\x1B[47m");		// Print foreground white color
 }
 
-int fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
+FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 	int pressed = 0;
-	int assignedOp[4] = {0};
+	FileOperation assignedOp[4] = {FileOperation::none};
 	int optionOffset = 0;
 	int cursorScreenPos = 0;
 	int maxCursors = -1;
@@ -208,33 +209,39 @@ int fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 	if (!entry->isDirectory) {
 		if (entry->isApp) {
 			maxCursors++;
-			assignedOp[maxCursors] = 0;
+			assignedOp[maxCursors] = FileOperation::bootFile;
 			printf("   Boot file\n");
 		}
 		if(extension(entry->name, {"nds", "dsi", "ids", "app"}))
 		{
 			maxCursors++;
-			assignedOp[maxCursors] = 3;
+			assignedOp[maxCursors] = FileOperation::mountNitroFS;
 			printf("   Mount NitroFS\n");
+		}
+		else if(extension(entry->name, {"sav"}))
+		{
+			maxCursors++;
+			assignedOp[maxCursors] = FileOperation::restoreSave;
+			printf("   Restore save\n");
 		}
 		else if(extension(entry->name, {"img", "sd"}))
 		{
 			maxCursors++;
-			assignedOp[maxCursors] = 5;
+			assignedOp[maxCursors] = FileOperation::mountImg;
 			printf("   Mount as FAT image\n");
 		}
 	}
 	maxCursors++;
-	assignedOp[maxCursors] = 4;
+	assignedOp[maxCursors] = FileOperation::showInfo;
 	printf(entry->isDirectory ? "	Show directory info\n" : "	Show file info\n");
 	if (sdMounted && (strcmp (path, "sd:/gm9i/out/") != 0)) {
 		maxCursors++;
-		assignedOp[maxCursors] = 1;
+		assignedOp[maxCursors] = FileOperation::copySdOut;
 		printf("   Copy to sd:/gm9i/out\n");
 	}
 	if (flashcardMounted && (strcmp (path, "fat:/gm9i/out/") != 0)) {
 		maxCursors++;
-		assignedOp[maxCursors] = 2;
+		assignedOp[maxCursors] = FileOperation::copyFatOut;
 		printf("   Copy to fat:/gm9i/out\n");
 	}
 	printf("\n");
@@ -274,75 +281,88 @@ int fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 		if (optionOffset > maxCursors)		optionOffset = 0;		// Wrap around to top of list
 
 		if (pressed & KEY_A) {
-			if (assignedOp[optionOffset] == 0) {
-				applaunch = true;
-				iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
-				printf("Now loading...");
-			} else if (assignedOp[optionOffset] == 1) {
-				if (access("sd:/gm9i", F_OK) != 0) {
+			switch(assignedOp[optionOffset]) {
+				case FileOperation::bootFile: {
+					applaunch = true;
 					iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
-					printf("Creating directory...");
-					mkdir("sd:/gm9i", 0777);
-				}
-				if (access("sd:/gm9i/out", F_OK) != 0) {
+					printf("Now loading...");
+					break;
+				} case FileOperation::restoreSave: {
+					ndsCardSaveRestore(entry->name.c_str());
+					break;
+				} case FileOperation::copySdOut: {
+					if (access("sd:/gm9i", F_OK) != 0) {
+						iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
+						printf("Creating directory...");
+						mkdir("sd:/gm9i", 0777);
+					}
+					if (access("sd:/gm9i/out", F_OK) != 0) {
+						iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
+						printf("Creating directory...");
+						mkdir("sd:/gm9i/out", 0777);
+					}
+					char destPath[256];
+					snprintf(destPath, sizeof(destPath), "sd:/gm9i/out/%s", entry->name.c_str());
 					iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
-					printf("Creating directory...");
-					mkdir("sd:/gm9i/out", 0777);
-				}
-				char destPath[256];
-				snprintf(destPath, sizeof(destPath), "sd:/gm9i/out/%s", entry->name.c_str());
-				iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
-				printf("Copying...        	 ");
-				remove(destPath);
-				char sourceFolder[PATH_MAX];
-				getcwd(sourceFolder, PATH_MAX);
-				char sourcePath[PATH_MAX];
-				snprintf(sourcePath, sizeof(sourcePath), "%s%s", sourceFolder, entry->name.c_str());
-				fcopy(sourcePath, destPath);
-				chdir(sourceFolder);	// For after copying a folder
-			} else if (assignedOp[optionOffset] == 2) {
-				if (access("fat:/gm9i", F_OK) != 0) {
+					printf("Copying...        	 ");
+					remove(destPath);
+					char sourceFolder[PATH_MAX];
+					getcwd(sourceFolder, PATH_MAX);
+					char sourcePath[PATH_MAX];
+					snprintf(sourcePath, sizeof(sourcePath), "%s%s", sourceFolder, entry->name.c_str());
+					fcopy(sourcePath, destPath);
+					chdir(sourceFolder);	// For after copying a folder
+					break;
+				} case FileOperation::copyFatOut: {
+					if (access("fat:/gm9i", F_OK) != 0) {
+						iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
+						printf("Creating directory...");
+						mkdir("fat:/gm9i", 0777);
+					}
+					if (access("fat:/gm9i/out", F_OK) != 0) {
+						iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
+						printf("Creating directory...");
+						mkdir("fat:/gm9i/out", 0777);
+					}
+					char destPath[256];
+					snprintf(destPath, sizeof(destPath), "fat:/gm9i/out/%s", entry->name.c_str());
 					iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
-					printf("Creating directory...");
-					mkdir("fat:/gm9i", 0777);
-				}
-				if (access("fat:/gm9i/out", F_OK) != 0) {
-					iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
-					printf("Creating directory...");
-					mkdir("fat:/gm9i/out", 0777);
-				}
-				char destPath[256];
-				snprintf(destPath, sizeof(destPath), "fat:/gm9i/out/%s", entry->name.c_str());
-				iprintf ("\x1b[%d;3H", optionOffset + OPTIONS_ENTRIES_START_ROW+cursorScreenPos);
-				printf("Copying...        	 ");
-				remove(destPath);
-				char sourceFolder[PATH_MAX];
-				getcwd(sourceFolder, PATH_MAX);
-				char sourcePath[PATH_MAX];
-				snprintf(sourcePath, sizeof(sourcePath), "%s%s", sourceFolder, entry->name.c_str());
-				fcopy(sourcePath, destPath);
-				chdir(sourceFolder);	// For after copying a folder
-			} else if (assignedOp[optionOffset] == 3) {
-				nitroMounted = nitroFSInit(entry->name.c_str());
-				if (nitroMounted) {
-					chdir("nitro:/");
-					nitroCurrentDrive = currentDrive;
-					currentDrive = 5;
-				}
-			} else if (assignedOp[optionOffset] == 4) {
-				changeFileAttribs(entry);
-			} else if (assignedOp[optionOffset] == 5) {
-				imgMounted = imgMount(entry->name.c_str());
-				if (imgMounted) {
-					chdir("img:/");
-					imgCurrentDrive = currentDrive;
-					currentDrive = 6;
+					printf("Copying...        	 ");
+					remove(destPath);
+					char sourceFolder[PATH_MAX];
+					getcwd(sourceFolder, PATH_MAX);
+					char sourcePath[PATH_MAX];
+					snprintf(sourcePath, sizeof(sourcePath), "%s%s", sourceFolder, entry->name.c_str());
+					fcopy(sourcePath, destPath);
+					chdir(sourceFolder);	// For after copying a folder
+					break;
+				} case FileOperation::mountNitroFS: {
+					nitroMounted = nitroFSInit(entry->name.c_str());
+					if (nitroMounted) {
+						chdir("nitro:/");
+						nitroCurrentDrive = currentDrive;
+						currentDrive = 5;
+					}
+					break;
+				} case FileOperation::showInfo: {
+					changeFileAttribs(entry);
+					break;
+				} case FileOperation::mountImg: {
+					imgMounted = imgMount(entry->name.c_str());
+					if (imgMounted) {
+						chdir("img:/");
+						imgCurrentDrive = currentDrive;
+						currentDrive = 6;
+					}
+					break;
+				} case FileOperation::none: {
+					break;
 				}
 			}
 			return assignedOp[optionOffset];
 		}
 		if (pressed & KEY_B) {
-			return -1;
+			return FileOperation::none;
 		}
 	}
 }
@@ -586,17 +606,21 @@ std::string browseForFile (void) {
 				screenOffset = 0;
 				fileOffset = 0;
 			} else {
-				int getOp = fileBrowse_A(entry, path);
-				if (getOp == 0) {
+				FileOperation getOp = fileBrowse_A(entry, path);
+				if(getOp == FileOperation::bootFile) {
 					// Return the chosen file
 					return entry->name;
-				} else if (getOp == 1 || getOp == 2 || (getOp == 3 && nitroMounted) || (getOp == 5 && imgMounted)) {
-					getDirectoryContents (dirContents);		// Refresh directory listing
-					if ((getOp == 3 && nitroMounted) || (getOp == 5 && imgMounted)) {
+				} else if (getOp == FileOperation::copySdOut
+						|| getOp == FileOperation::copyFatOut
+						|| (getOp == FileOperation::mountNitroFS && nitroMounted)
+						|| (getOp == FileOperation::mountImg && imgMounted)) {
+					getDirectoryContents(dirContents); // Refresh directory listing
+					if ((getOp == FileOperation::mountNitroFS && nitroMounted)
+					 || (getOp == FileOperation::mountImg && imgMounted)) {
 						screenOffset = 0;
 						fileOffset = 0;
 					}
-				} else if (getOp == 4) {
+				} else if(getOp == FileOperation::showInfo) {
 					for (int i = 0; i < 15; i++) swiWaitForVBlank();
 				}
 			}
@@ -608,14 +632,10 @@ std::string browseForFile (void) {
 				screenMode = 0;
 				return "null";
 			} else {
-				int getOp = fileBrowse_A(entry, path);
-				if (getOp == 1 || getOp == 2) {
+				FileOperation getOp = fileBrowse_A(entry, path);
+				if (getOp == FileOperation::copySdOut || getOp == FileOperation::copyFatOut) {
 					getDirectoryContents (dirContents);		// Refresh directory listing
-					if (getOp == 3 && nitroMounted) {
-						screenOffset = 0;
-						fileOffset = 0;
-					}
-				} else if (getOp == 4) {
+				} else if (getOp == FileOperation::showInfo) {
 					for (int i = 0; i < 15; i++) swiWaitForVBlank();
 				}
 			}

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -55,11 +55,13 @@ extern void reinitConsoles(void);
 
 static char path[PATH_MAX];
 
-bool nameEndsWith (const string& name) {
+bool extension(const std::string &filename, const std::vector<std::string> &extensions) {
+	for(const std::string &ext : extensions) {
+		if(filename.length() > ext.length() && strcasecmp(filename.substr(filename.length() - ext.length()).data(), ext.data()) == 0)
+			return true;
+	}
 
-	if (name.size() == 0) return false;
-
-	return true;
+	return false;
 }
 
 void OnKeyPressed(int key) {
@@ -102,27 +104,15 @@ void getDirectoryContents (std::vector<DirEntry>& dirContents) {
 				if (!dirEntry.isDirectory) {
 					dirEntry.size = getFileSize(dirEntry.name.c_str());
 				}
-				if ((dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "nds")
-				|| (dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "NDS")
-				|| (dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "argv")
-				|| (dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "ARGV")
-				|| (dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "dsi")
-				|| (dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "DSI")
-				|| (dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "ids")
-				|| (dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "IDS")
-				|| (dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "app")
-				|| (dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "APP"))
-				{
+				if (extension(dirEntry.name, {"nds", "argv", "dsi", "ids", "app"})) {
 					dirEntry.isApp = ((currentDrive == 0 && sdMounted) || (currentDrive == 1 && flashcardMounted));
-				} else if ((dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "firm")
-						|| (dirEntry.name.substr(dirEntry.name.find_last_of(".") + 1) == "FIRM"))
-				{
+				} else if (extension(dirEntry.name, {"firm"})) {
 					dirEntry.isApp = (isDSiMode() && is3DS && sdMounted);
 				} else {
 					dirEntry.isApp = false;
 				}
 
-				if (dirEntry.name.compare(".") != 0 && (dirEntry.isDirectory || nameEndsWith(dirEntry.name))) {
+				if (dirEntry.name.compare(".") != 0) {
 					dirContents.push_back (dirEntry);
 				}
 			}
@@ -221,24 +211,13 @@ int fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 			assignedOp[maxCursors] = 0;
 			printf("   Boot file\n");
 		}
-		if((entry->name.substr(entry->name.find_last_of(".") + 1) == "nds")
-		|| (entry->name.substr(entry->name.find_last_of(".") + 1) == "NDS")
-		|| (entry->name.substr(entry->name.find_last_of(".") + 1) == "dsi")
-		|| (entry->name.substr(entry->name.find_last_of(".") + 1) == "DSI")
-		|| (entry->name.substr(entry->name.find_last_of(".") + 1) == "ids")
-		|| (entry->name.substr(entry->name.find_last_of(".") + 1) == "IDS")
-		|| (entry->name.substr(entry->name.find_last_of(".") + 1) == "app")
-		|| (entry->name.substr(entry->name.find_last_of(".") + 1) == "APP"))
+		if(extension(entry->name, {"nds", "dsi", "ids", "app"}))
 		{
 			maxCursors++;
 			assignedOp[maxCursors] = 3;
 			printf("   Mount NitroFS\n");
 		}
-		else
-		if((entry->name.substr(entry->name.find_last_of(".") + 1) == "img")
-		|| (entry->name.substr(entry->name.find_last_of(".") + 1) == "IMG")
-		|| (entry->name.substr(entry->name.find_last_of(".") + 1) == "sd")
-		|| (entry->name.substr(entry->name.find_last_of(".") + 1) == "SD"))
+		else if(extension(entry->name, {"img", "sd"}))
 		{
 			maxCursors++;
 			assignedOp[maxCursors] = 5;

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -78,7 +78,7 @@ bool dirEntryPredicate (const DirEntry& lhs, const DirEntry& rhs) {
 	return strcasecmp(lhs.name.c_str(), rhs.name.c_str()) < 0;
 }
 
-void getDirectoryContents (vector<DirEntry>& dirContents) {
+void getDirectoryContents (std::vector<DirEntry>& dirContents) {
 	struct stat st;
 
 	dirContents.clear();
@@ -141,7 +141,7 @@ void getDirectoryContents (vector<DirEntry>& dirContents) {
 	dirContents.insert (dirContents.begin(), dirEntry);	// Add ".." to top of list
 }
 
-void showDirectoryContents (const vector<DirEntry>& dirContents, int fileOffset, int startRow) {
+void showDirectoryContents (const std::vector<DirEntry>& dirContents, int fileOffset, int startRow) {
 	getcwd(path, PATH_MAX);
 
 	consoleClear();
@@ -519,12 +519,12 @@ void fileBrowse_drawBottomScreen(DirEntry* entry) {
 	}
 }
 
-string browseForFile (void) {
+std::string browseForFile (void) {
 	int pressed = 0;
 	int held = 0;
 	int screenOffset = 0;
 	int fileOffset = 0;
-	vector<DirEntry> dirContents;
+	std::vector<DirEntry> dirContents;
 
 	getDirectoryContents (dirContents);
 

--- a/arm9/source/file_browse.h
+++ b/arm9/source/file_browse.h
@@ -32,6 +32,8 @@ struct DirEntry {
 	bool isApp;
 };
 
+bool extension(const std::string &filename, const std::vector<std::string> &extensions);
+
 std::string browseForFile (void);
 void getDirectoryContents (std::vector<DirEntry>& dirContents);
 

--- a/arm9/source/file_browse.h
+++ b/arm9/source/file_browse.h
@@ -25,17 +25,15 @@
 #include <string>
 #include <vector>
 
-using namespace std;
-
 struct DirEntry {
-	string name;
+	std::string name;
 	size_t size;
 	bool isDirectory;
 	bool isApp;
-} ;
+};
 
 std::string browseForFile (void);
-void getDirectoryContents (vector<DirEntry>& dirContents);
+void getDirectoryContents (std::vector<DirEntry>& dirContents);
 
 
 

--- a/arm9/source/file_browse.h
+++ b/arm9/source/file_browse.h
@@ -32,6 +32,17 @@ struct DirEntry {
 	bool isApp;
 };
 
+enum class FileOperation {
+	none,
+	bootFile,
+	mountNitroFS,
+	mountImg,
+	restoreSave,
+	showInfo,
+	copySdOut,
+	copyFatOut,
+};
+
 bool extension(const std::string &filename, const std::vector<std::string> &extensions);
 
 std::string browseForFile (void);

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -54,8 +54,6 @@ static int bg3;
 
 PrintConsole topConsoleBG, topConsole, bottomConsoleBG, bottomConsole;
 
-using namespace std;
-
 //---------------------------------------------------------------------------------
 void stop (void) {
 //---------------------------------------------------------------------------------
@@ -275,7 +273,7 @@ int main(int argc, char **argv) {
 			// Construct a command line
 			getcwd (filePath, PATH_MAX);
 			pathLen = strlen (filePath);
-			vector<char*> argarray;
+			std::vector<char*> argarray;
 
 			if ((strcasecmp (filename.c_str() + filename.size() - 5, ".argv") == 0)
 			|| (strcasecmp (filename.c_str() + filename.size() - 5, ".ARGV") == 0)) {

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -64,14 +64,6 @@ void stop (void) {
 
 char filePath[PATH_MAX];
 
-bool extention(const std::string& filename, const char* ext) {
-	if(strcasecmp(filename.c_str() + filename.size() - strlen(ext), ext)) {
-		return false;
-	} else {
-		return true;
-	}
-}
-
 void printBorderTop(void) {
 	consoleSelect(&topConsoleBG);
 	printf ("\x1B[42m");		// Print green color
@@ -301,8 +293,7 @@ int main(int argc, char **argv) {
 				argarray.push_back(strdup(filename.c_str()));
 			}
 
-			if (extention(filename, ".nds") || extention(filename, ".dsi")
-			 || extention(filename, ".ids") || extention(filename, ".app")) {
+			if (extension(filename, {"nds", "dsi", "ids", "app"})) {
 				char *name = argarray.at(0);
 				strcpy (filePath + pathLen, name);
 				free(argarray.at(0));
@@ -313,7 +304,7 @@ int main(int argc, char **argv) {
 				iprintf ("\x1b[31mStart failed. Error %i\n", err);
 			}
 
-			if (extention(filename, ".firm")) {
+			if (extension(filename, {"firm"})) {
 				char *name = argarray.at(0);
 				strcpy (filePath + pathLen, name);
 				free(argarray.at(0));


### PR DESCRIPTION
This adds save file restoring (fixes #56), as well as a few misc cleanup things that were bothering me ;P
- Removes `using namespace std`
- Renames `extention` to `extension` and improves it a bit
- Switches save dumping to use FILEs instead of fstreams (cuts the file size nearly in half)
- Makes file operations use an enum class instead of magic numbers

Restoring will throw a warning if you try to restore a file of the wrong size, but it will try to restore files from other games if their the right size as unfortunately there's no way to prevent this as saves don't contain any standardized headers or so.

---

Tested on DSi (K) with the latest Unlaunch using 매일매닐 DS 두뇌 트레이닝 (K) and Pokémon Black Version 2 (U)