### PR TITLE
Make .dsi file with title ID, and the .nds without it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 */build
+*.dsi
 *.nds
 *.cia
 *.elf

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,8 @@ export GAME_TITLE := $(TARGET)
 .PHONY: bootloader bootstub clean arm7/$(TARGET).elf arm9/$(TARGET).elf
 
 all:	bootloader bootstub $(TARGET).nds
+
+dsi:	$(TARGET).dsi
 	
 dist:	all
 	@rm	-fr	hbmenu
@@ -131,8 +133,14 @@ dist:	all
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
 			-b icon.bmp "GodMode9i;RocketRobz" \
-			-g HGMA 00 "GODMODE9I" -z 80040000 -u 00030004
+			-z 80040000 -u 00030004
 	python2 fix_ndsheader.py $(CURDIR)/$(TARGET).nds
+	
+$(TARGET).dsi:	$(TARGET).arm7 $(TARGET).arm9
+	ndstool	-c $(TARGET).dsi -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
+			-b icon.bmp "GodMode9i;RocketRobz" \
+			-g HGMA 00 "GODMODE9I" -z 80040000 -u 00030004
+	python2 fix_ndsheader.py $(CURDIR)/$(TARGET).dsi
 
 $(TARGET).arm7: arm7/$(TARGET).elf
 	cp arm7/$(TARGET).elf $(TARGET).arm7.elf

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,13 +37,14 @@ steps:
     export DEVKITPRO="/opt/devkitpro"
     export DEVKITARM="/opt/devkitpro/devkitARM"
     sudo cp libmm7.a /opt/devkitpro/libnds/lib/libmm7.a
-    make
+    make all dsi
   displayName: 'Build GodMode9i'
 
 - script: |
     chmod +x make_cia
-    ./make_cia --srl="GodMode9i.nds" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
+    ./make_cia --srl="GodMode9i.dsi" --id_0=$(git rev-parse --short=7 HEAD) --tikID=$(git rev-parse --short=16 HEAD)
     mkdir GodMode9i/
+    cp GodMode9i.dsi GodMode9i/
     cp GodMode9i.nds GodMode9i/
     cp GodMode9i.cia GodMode9i/
     7z a GodMode9i.7z GodMode9i/


### PR DESCRIPTION
Since the title ID is the only thing preventing this from running on most flashcard kernels, but it's only needed for making the CIA and installing with TMFH, both of which .dsi is an acceptable extension for, why not do the .nds without it and make another for that.

Might just want to add a note about it in the next release or so since it could be a bit confusing, this is the best way I can think of to have both TMFH and flashcard kernels be happy though so I think I'm going to start doing this for pkmn-chest and such too.