### PR TITLE
Separate the selection and the clipboard like GM9

### DIFF
--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -743,18 +743,23 @@ std::string browseForFile (void) {
 			}
 		}
 
-		// Delete file/folder
+		// Delete action
 		if ((pressed & KEY_X) && (entry->name != ".." && strncmp(path, "nitro:/", 7) != 0)) {
 			consoleSelect(&bottomConsole);
 			consoleClear();
 			printf ("\x1B[47m");		// Print foreground white color
-			if (entry->selected) {
-				int count = 0;
-				for (const auto &item : dirContents) {
-					if (item.selected)
-						count++;
+			int selections = std::count_if(dirContents.begin(), dirContents.end(), [](const DirEntry &x){ return x.selected; });
+			if (entry->selected && selections > 1) {
+				iprintf("Delete %d paths?\n", selections);
+				for (uint i = 0, printed = 0; i < dirContents.size() && printed < 5; i++) {
+					if (dirContents[i].selected) {
+						iprintf("\x1B[41m- %s\n", dirContents[i].name.c_str());
+						printed++;
+					}
 				}
-				iprintf("Delete %d path(s)?\n", count);
+				if(selections > 5)
+					iprintf("\x1B[41m- and %d more...\n", selections - 5);
+				iprintf("\x1B[47m");
 			} else {
 				iprintf("Delete \"%s\"?\n", entry->name.c_str());
 			}

--- a/arm9/source/file_browse.h
+++ b/arm9/source/file_browse.h
@@ -30,6 +30,7 @@ struct DirEntry {
 	size_t size;
 	bool isDirectory;
 	bool isApp;
+	bool selected = false;
 };
 
 enum class FileOperation {

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -112,6 +112,10 @@ void reinitConsoles(void) {
 	BG_PALETTE[15+(7*16)] = 0x656A;
 	BG_PALETTE_SUB[15+(7*16)] = 0x656A;
 
+	// Custom yellow color
+	BG_PALETTE[15+(3*16)] = 0x3339;
+	BG_PALETTE_SUB[15+(3*16)] = 0x3339;
+
 	// Overwrite 2nd smiley face with filled tile
 	dmaFillWords(0xFFFFFFFF, (void*)0x6000040, 8*8);	// Top screen
 	dmaFillWords(0xFFFFFFFF, (void*)0x6200040, 8*8);	// Bottom screen
@@ -247,6 +251,10 @@ int main(int argc, char **argv) {
 	// Overwrite background white color
 	BG_PALETTE[15+(7*16)] = 0x656A;
 	BG_PALETTE_SUB[15+(7*16)] = 0x656A;
+
+	// Custom yellow color
+	BG_PALETTE[15+(3*16)] = 0x3339;
+	BG_PALETTE_SUB[15+(3*16)] = 0x3339;
 
 	// Overwrite 2nd smiley face with filled tile
 	dmaFillWords(0xFFFFFFFF, (void*)0x6000040, 8*8);	// Top screen


### PR DESCRIPTION
Now when pressing <kbd>L</kbd> on an item it only selects it, coloring it yellow, then the selection can be added to the clipboard with <kbd>Y</kbd> or deleted using <kbd>X</kbd> when on a selected item. The clipboard is now completely separate from deleting.

You can also hold <kbd>L</kbd> and press Left to deselect all, Right to select all, or Up/Down to select/deselect nearby items, like GodMode9.

Closes #80 