### PR TITLE
fix_ndsheader.py compatibility fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,13 +134,13 @@ $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
 			-b icon.bmp "GodMode9i;RocketRobz" \
 			-z 80040000 -u 00030004
-	python2 fix_ndsheader.py $(CURDIR)/$(TARGET).nds
+	python fix_ndsheader.py $(CURDIR)/$(TARGET).nds
 	
 $(TARGET).dsi:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).dsi -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
 			-b icon.bmp "GodMode9i;RocketRobz" \
 			-g HGMA 00 "GODMODE9I" -z 80040000 -u 00030004
-	python2 fix_ndsheader.py $(CURDIR)/$(TARGET).dsi
+	python fix_ndsheader.py $(CURDIR)/$(TARGET).dsi
 
 $(TARGET).arm7: arm7/$(TARGET).elf
 	cp arm7/$(TARGET).elf $(TARGET).arm7.elf


### PR DESCRIPTION
The fix_ndsheader.py script was not compatible with python 3.x but required an obsolete python 2.x version.

This requirement was fixed. The script now works for Version 2.x and 3.x. 
The fixed reference to python2 was removed from the makefile so that any available python version will be used and the developer does no longer need to install the obsolete version.

The fix is backward compatible: The script still works if only python2 is installed.