### PR TITLE
Add hex editor

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -53,7 +53,7 @@ jobs:
           echo ::set-output name=author_name::$(git log -1 "$GITHUB_SHA" --pretty="%aN")
           echo ::set-output name=committer_name::$(git log -1 "$GITHUB_SHA" --pretty="%cN")
           echo ::set-output name=commit_subject::$(git log -1 "$GITHUB_SHA" --pretty="%s")
-          echo ::set-output name=commit_message::$(git log -1 "$GITHUB_SHA" --pretty="%b")
+          echo ::set-output name=commit_message::$(git log -1 "$GITHUB_SHA" --pretty="%B")
       - name: Publish build to GH Actions
         uses: actions/upload-artifact@v2
         with:

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -15,7 +15,7 @@ else
 GIT_VER := $(shell git describe --abbrev=0 --tags)-$(shell git rev-parse --short HEAD)
 endif
 
-# Ensure version.hpp exists
+# Ensure version.h exists
 ifeq (,$(wildcard include/version.h))
 $(shell mkdir -p include)
 $(shell touch include/version.h)

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -8,11 +8,11 @@ endif
 
 include $(DEVKITARM)/ds_rules
 
-# If on a tagged commit, use the tag instead of the commit
+# If on a tagged commit, use just tag
 ifneq ($(shell echo $(shell git tag -l --points-at HEAD) | head -c 1),)
 GIT_VER := $(shell git tag -l --points-at HEAD)
 else
-GIT_VER := $(shell git describe --abbrev=0 --tags)-$(shell git rev-parse --short HEAD)
+GIT_VER := $(shell git describe --abbrev=0 --tags)-$(shell git rev-parse --short=7 HEAD)
 endif
 
 # Ensure version.h exists

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -379,7 +379,7 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 					}
 					break;
 				} case FileOperation::hexEdit: {
-					hexEditor(entry->name.c_str());
+					hexEditor(entry->name.c_str(), currentDrive);
 					break;
 				} case FileOperation::none: {
 					break;

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -38,6 +38,7 @@
 #include "driveMenu.h"
 #include "driveOperations.h"
 #include "dumpOperations.h"
+#include "hexEditor.h"
 #include "nitrofs.h"
 #include "inifile.h"
 #include "nds_loader_arm9.h"
@@ -231,6 +232,8 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 			assignedOp[++maxCursors] = FileOperation::mountImg;
 			printf("   Mount as FAT image\n");
 		}
+		assignedOp[++maxCursors] = FileOperation::hexEdit;
+		printf("   Open in hex editor\n");
 	}
 	assignedOp[++maxCursors] = FileOperation::showInfo;
 	printf(entry->isDirectory ? "	Show directory info\n" : "	Show file info\n");
@@ -374,6 +377,9 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 						imgCurrentDrive = currentDrive;
 						currentDrive = 6;
 					}
+					break;
+				} case FileOperation::hexEdit: {
+					hexEditor(entry->name.c_str());
 					break;
 				} case FileOperation::none: {
 					break;

--- a/arm9/source/file_browse.h
+++ b/arm9/source/file_browse.h
@@ -47,6 +47,7 @@ enum class FileOperation {
 };
 
 bool extension(const std::string &filename, const std::vector<std::string> &extensions);
+void OnKeyPressed(int key);
 
 std::string browseForFile (void);
 void getDirectoryContents (std::vector<DirEntry>& dirContents);

--- a/arm9/source/file_browse.h
+++ b/arm9/source/file_browse.h
@@ -43,6 +43,7 @@ enum class FileOperation {
 	showInfo,
 	copySdOut,
 	copyFatOut,
+	hexEdit,
 };
 
 bool extension(const std::string &filename, const std::vector<std::string> &extensions);

--- a/arm9/source/hexEditor.cpp
+++ b/arm9/source/hexEditor.cpp
@@ -1,0 +1,177 @@
+#include "hexEditor.h"
+
+#include "tonccpy.h"
+
+#include <nds.h>
+#include <stdio.h>
+
+
+u32 jumpToOffset(u32 offset) {
+	consoleClear();
+
+	u8 cursorPosition = 0;
+	u16 pressed = 0, held = 0;
+	while(1) {
+		printf("\x1B[9;6H\x1B[47m-------------------");
+		printf("\x1B[10;8H\x1B[47mJump to Offset");
+		printf("\x1B[12;11H\x1B[33m%08lx", offset);
+		printf("\x1B[12;%dH\x1B[43m%lx", 17 - cursorPosition, (offset >> ((cursorPosition + 1) * 4)) & 0xF);
+		printf("\x1B[13;6H\x1B[47m-------------------");
+
+		do {
+			swiWaitForVBlank();
+			scanKeys();
+			pressed = keysDown();
+			held = keysDownRepeat();
+		} while(!held);
+
+		if(held & KEY_UP) {
+			offset += 0x10 << (cursorPosition * 4);
+		} else if(held & KEY_DOWN) {
+			offset -= 0x10 << (cursorPosition * 4);
+		} else if(held & KEY_LEFT) {
+			if(cursorPosition < 6)
+				cursorPosition++;
+		} else if(held & KEY_RIGHT) {
+			if(cursorPosition > 0)
+				cursorPosition--;
+		} else if(pressed & (KEY_A | KEY_B)) {
+			return offset;
+		}
+	}
+}
+
+void hexEditor(const char *path) {
+	FILE *file = fopen(path, "rb+");
+
+	if(!file)
+		return;
+
+	consoleClear();
+
+	fseek(file, 0, SEEK_END);
+	u32 fileSize = ftell(file);
+	fseek(file, 0, SEEK_SET);
+
+	u8 cursorPosition = 0, mode = 0;
+	u16 pressed = 0, held = 0;
+	u32 offset = 0;
+
+	char data[8 * 23];
+	fseek(file, offset, SEEK_SET);
+	fread(data, 1, sizeof(data), file);
+
+	while(1) {
+		printf("\x1B[0;11H\x1B[42mHex Editor");
+		printf("\x1B[0;0H\x1B[37m%04lx", offset >> 0x10);
+
+		if(mode < 2 && held & (KEY_UP | KEY_DOWN | KEY_LEFT | KEY_RIGHT)) {
+			fseek(file, offset, SEEK_SET);
+			fread(data, 1, sizeof(data), file);
+		}
+
+		for(int i = 0; i < 23; i++) {
+			printf("\x1B[%d;0H\x1B[37m%04lx", i + 1, (offset + i * 8) & 0xFFFF);
+			for(int j = 0; j < 4; j++)
+				printf("\x1B[%d;%dH\x1B[%dm%02x", i + 1, 5 + (j * 2), (mode > 0 && i * 8 + j == cursorPosition) ? (mode > 1 ? 41 : 31) : 33, data[i * 8 + j]);
+			for(int j = 0; j < 4; j++)
+				printf("\x1B[%d;%dH\x1B[%dm%02x", i + 1, 14 + (j * 2), (mode > 0 && i * 8 + 4 + j == cursorPosition) ? (mode > 1 ? 41 : 31) : 33, data[i * 8 + 4 + j]);
+			char line[9] = {0};
+			for(int j = 0; j < 8; j++) {
+				char c = data[i * 8 + j];
+				if(c < ' ' || c > 127)
+					line[j] = ' ';
+				else
+					line[j] = c;
+			}
+			printf("\x1B[%d;%dH\x1B[47m%.8s", i + 1, 23, line);
+		}
+
+		// Change color of selected char
+		if(mode > 0)
+			printf("\x1B[%d;%dH\x1B[%dm%c", 1 + cursorPosition / 8, 23 + cursorPosition % 8, mode > 1 ? 41 : 31, data[cursorPosition]);
+
+		do {
+			swiWaitForVBlank();
+			scanKeys();
+			pressed = keysDown();
+			held = keysDownRepeat();
+		} while(!held);
+
+		if(mode == 0) {
+			if (held & KEY_UP) {
+				if(offset > 8)
+					offset -= 8;
+				else
+					offset = 0;
+			} else if (held & KEY_DOWN) {
+				if(offset < fileSize - 8 * 23)
+					offset += 8;
+				else
+					offset = fileSize - 8 * 23;
+			} else if (held & KEY_LEFT) {
+				if(offset > 8 * 23)
+					offset -= 8 * 23;
+				else
+					offset = 0;
+			} else if (held & KEY_RIGHT) {
+				if(offset < fileSize - 8 * 23)
+					offset += 8 * 23;
+				else
+					offset = fileSize - 8 * 23;
+			} else if (pressed & KEY_A) {
+				mode = 1;
+			} else if (pressed & KEY_B) {
+				return;
+			} else if(pressed & KEY_Y) {
+				offset = jumpToOffset(offset);
+				consoleClear();
+			}
+		} else if(mode == 1) {
+			if (held & KEY_UP) {
+				if(cursorPosition >= 8)
+					cursorPosition -= 8;
+				else if(offset > 8)
+					offset -= 8;
+				else
+					offset = 0;
+			} else if (held & KEY_DOWN) {
+				if(cursorPosition < 8 * 22)
+					cursorPosition += 8;
+				else if(offset < fileSize - 8 * 23)
+					offset += 8;
+				else
+					offset = fileSize - 8 * 23;
+			} else if (held & KEY_LEFT) {
+				if(cursorPosition > 0)
+					cursorPosition--;
+			} else if (held & KEY_RIGHT) {
+				if(cursorPosition < 8 * 23 - 1)
+					cursorPosition++;
+			} else if (pressed & KEY_A) {
+				mode = 2;
+			} else if (pressed & KEY_B) {
+				mode = 0;
+			} else if(pressed & KEY_Y) {
+				offset = jumpToOffset(offset);
+				consoleClear();
+			}
+		} else if(mode == 2) {
+			if (held & KEY_UP) {
+				data[cursorPosition]++;
+			} else if (held & KEY_DOWN) {
+				data[cursorPosition]--;
+			} else if (held & KEY_LEFT) {
+				data[cursorPosition] += 0x10;
+			} else if (held & KEY_RIGHT) {
+				data[cursorPosition] -= 0x10;
+			} else if (pressed & (KEY_A | KEY_B)) {
+				mode = 1;
+				fseek(file, offset + cursorPosition, SEEK_SET);
+				fwrite(data + cursorPosition, 1, 1, file);
+			}
+		}
+	}
+
+	fclose(file);
+}

--- a/arm9/source/hexEditor.cpp
+++ b/arm9/source/hexEditor.cpp
@@ -50,17 +50,19 @@ u32 jumpToOffset(u32 offset) {
 	}
 }
 
-void hexEditor(const char *path) {
+void hexEditor(const char *path, int drive) {
 	// Custom palettes
 	BG_PALETTE_SUB[0x1F] = 0x9CF7;
 	BG_PALETTE_SUB[0x2F] = 0xB710;
 	BG_PALETTE_SUB[0x3F] = 0xAE8D;
 	BG_PALETTE_SUB[0x7F] = 0xEA2D;
 
-	FILE *file = fopen(path, "rb+");
+	FILE *file = fopen(path, drive < 4 ? "rb+" : "rb");
 
-	if(!file)
+	if(!file) {
+		nocashMessage("test");
 		return;
+	}
 
 	consoleClear();
 
@@ -179,11 +181,13 @@ void hexEditor(const char *path) {
 				if(cursorPosition < 8 * maxLines - 1)
 					cursorPosition = std::min((u8)(cursorPosition + 1), (u8)(fileSize - offset - 1));
 			} else if (pressed & KEY_A) {
-				mode = 2;
-				consoleSelect(&bottomConsoleBG);
-				printf("\x1B[%d;%dH\x1B[%dm\2\2", 1 + cursorPosition / 8, 5 + (cursorPosition % 8 * 2) + (cursorPosition % 8 / 4), 31);
-				printf("\x1B[%d;%dH\x1B[%dm\2", 1 + cursorPosition / 8, 23 + cursorPosition % 8, 31);
-				consoleSelect(&bottomConsole);
+				if(drive < 4) {
+					mode = 2;
+					consoleSelect(&bottomConsoleBG);
+					printf("\x1B[%d;%dH\x1B[%dm\2\2", 1 + cursorPosition / 8, 5 + (cursorPosition % 8 * 2) + (cursorPosition % 8 / 4), 31);
+					printf("\x1B[%d;%dH\x1B[%dm\2", 1 + cursorPosition / 8, 23 + cursorPosition % 8, 31);
+					consoleSelect(&bottomConsole);
+				}
 			} else if (pressed & KEY_B) {
 				mode = 0;
 			} else if(pressed & KEY_Y) {

--- a/arm9/source/hexEditor.cpp
+++ b/arm9/source/hexEditor.cpp
@@ -1,12 +1,18 @@
 #include "hexEditor.h"
 
+#include "date.h"
 #include "tonccpy.h"
 
+#include <algorithm>
 #include <nds.h>
 #include <stdio.h>
 
+extern PrintConsole bottomConsole, bottomConsoleBG, topConsole;
 
-u32 jumpToOffset(u32 offset, u32 limit) {
+u32 jumpToOffset(u32 offset) {
+	consoleSelect(&bottomConsoleBG);
+	consoleClear();
+	consoleSelect(&bottomConsole);
 	consoleClear();
 
 	u8 cursorPosition = 0;
@@ -14,23 +20,24 @@ u32 jumpToOffset(u32 offset, u32 limit) {
 	while(1) {
 		printf("\x1B[9;6H\x1B[47m-------------------");
 		printf("\x1B[10;8H\x1B[47mJump to Offset");
-		printf("\x1B[12;11H\x1B[33m%08lx", offset);
-		printf("\x1B[12;%dH\x1B[43m%lx", 17 - cursorPosition, (offset >> ((cursorPosition + 1) * 4)) & 0xF);
+		printf("\x1B[12;11H\x1B[37m%08lx", offset);
+		printf("\x1B[12;%dH\x1B[41m%lx", 17 - cursorPosition, (offset >> ((cursorPosition + 1) * 4)) & 0xF);
 		printf("\x1B[13;6H\x1B[47m-------------------");
 
+		consoleSelect(&topConsole);
 		do {
 			swiWaitForVBlank();
 			scanKeys();
 			pressed = keysDown();
 			held = keysDownRepeat();
+			printf("\x1B[30m\x1B[0;26H %s", RetTime().c_str()); // Print time
 		} while(!held);
+		consoleSelect(&bottomConsole);
 
 		if(held & KEY_UP) {
-			if(offset + (0x10 << (cursorPosition * 4)) < limit - 8 * 23)
-				offset += 0x10 << (cursorPosition * 4);
+			offset = (offset & ~(0xF0 << cursorPosition * 4)) | ((offset + (0x10 << (cursorPosition * 4))) & (0xF0 << cursorPosition * 4));
 		} else if(held & KEY_DOWN) {
-			if(offset - (0x10 << (cursorPosition * 4)) > 0)
-				offset -= 0x10 << (cursorPosition * 4);
+			offset = (offset & ~(0xF0 << cursorPosition * 4)) | ((offset - (0x10 << (cursorPosition * 4))) & (0xF0 << cursorPosition * 4));
 		} else if(held & KEY_LEFT) {
 			if(cursorPosition < 6)
 				cursorPosition++;
@@ -44,6 +51,12 @@ u32 jumpToOffset(u32 offset, u32 limit) {
 }
 
 void hexEditor(const char *path) {
+	// Custom palettes
+	BG_PALETTE_SUB[0x1F] = 0x9CF7;
+	BG_PALETTE_SUB[0x2F] = 0xB710;
+	BG_PALETTE_SUB[0x3F] = 0xAE8D;
+	BG_PALETTE_SUB[0x7F] = 0xEA2D;
+
 	FILE *file = fopen(path, "rb+");
 
 	if(!file)
@@ -55,29 +68,44 @@ void hexEditor(const char *path) {
 	u32 fileSize = ftell(file);
 	fseek(file, 0, SEEK_SET);
 
+	u8 maxLines = std::min(23lu, fileSize / 8);
+	u32 maxSize = ((fileSize - 8 * maxLines) & ~7) + (fileSize & 7 ? 8 : 0);
+
 	u8 cursorPosition = 0, mode = 0;
 	u16 pressed = 0, held = 0;
 	u32 offset = 0;
 
-	char data[8 * 23];
+	char data[8 * maxLines];
 	fseek(file, offset, SEEK_SET);
 	fread(data, 1, sizeof(data), file);
 
 	while(1) {
-		printf("\x1B[0;11H\x1B[42mHex Editor");
-		printf("\x1B[0;0H\x1B[37m%04lx", offset >> 0x10);
+		consoleSelect(&bottomConsoleBG);
+		printf ("\x1B[0;0H\x1B[46m"); // Blue
+		for (int i = 0; i < 4; i++)
+			printf ("\2");
+		printf ("\x1B[42m"); // Green
+		for (int i = 0; i < 32 - 4; i++)
+			printf ("\2");
+
+		consoleSelect(&bottomConsole);
+
+		printf("\x1B[0;11H\x1B[30mHex Editor");
+
+		printf("\x1B[0;0H\x1B[30m%04lx", offset >> 0x10);
 
 		if(mode < 2) {
 			fseek(file, offset, SEEK_SET);
-			fread(data, 1, sizeof(data), file);
+			toncset(data, 0, sizeof(data));
+			fread(data, 1, std::min((u32)sizeof(data), fileSize - offset), file);
 		}
 
-		for(int i = 0; i < 23; i++) {
+		for(int i = 0; i < maxLines; i++) {
 			printf("\x1B[%d;0H\x1B[37m%04lx", i + 1, (offset + i * 8) & 0xFFFF);
 			for(int j = 0; j < 4; j++)
-				printf("\x1B[%d;%dH\x1B[%dm%02x", i + 1, 5 + (j * 2), (mode > 0 && i * 8 + j == cursorPosition) ? (mode > 1 ? 41 : 31) : 33, data[i * 8 + j]);
+				printf("\x1B[%d;%dH\x1B[%dm%02x", i + 1, 5 + (j * 2), (mode > 0 && i * 8 + j == cursorPosition) ? (mode > 1 ? 30 : 31) : (offset + i * 8 + j >= fileSize ? 38 : 32 + (j % 2)), data[i * 8 + j]);
 			for(int j = 0; j < 4; j++)
-				printf("\x1B[%d;%dH\x1B[%dm%02x", i + 1, 14 + (j * 2), (mode > 0 && i * 8 + 4 + j == cursorPosition) ? (mode > 1 ? 41 : 31) : 33, data[i * 8 + 4 + j]);
+				printf("\x1B[%d;%dH\x1B[%dm%02x", i + 1, 14 + (j * 2), (mode > 0 && i * 8 + 4 + j == cursorPosition) ? (mode > 1 ? 30 : 31) : (offset + i * 8 + 4 + j >= fileSize ? 38 : 32 + (j % 2)), data[i * 8 + 4 + j]);
 			char line[9] = {0};
 			for(int j = 0; j < 8; j++) {
 				char c = data[i * 8 + j];
@@ -86,51 +114,50 @@ void hexEditor(const char *path) {
 				else
 					line[j] = c;
 			}
-			printf("\x1B[%d;%dH\x1B[47m%.8s", i + 1, 23, line);
+			printf("\x1B[%d;23H\x1B[47m%.8s", i + 1, line);
+			if(mode > 0 && cursorPosition / 8 == i) {
+				printf("\x1B[%d;%dH\x1B[%dm%c", i + 1, 23 + cursorPosition % 8, mode > 1 ? 30 : 31, line[cursorPosition % 8]);
+			}
 		}
 
-		// Change color of selected char
-		if(mode > 0) {
-			char c = data[cursorPosition];
-			if(c < ' ' || c > 127)
-				c = ' ';
-			printf("\x1B[%d;%dH\x1B[%dm%c", 1 + cursorPosition / 8, 23 + cursorPosition % 8, mode > 1 ? 41 : 31, c);
-		}
 
+		consoleSelect(&topConsole);
 		do {
 			swiWaitForVBlank();
 			scanKeys();
 			pressed = keysDown();
 			held = keysDownRepeat();
+			printf("\x1B[30m\x1B[0;26H %s", RetTime().c_str()); // Print time
 		} while(!held);
+		consoleSelect(&bottomConsole);
 
 		if(mode == 0) {
-			if (held & KEY_UP) {
+			if(keysHeld() & KEY_R && held & (KEY_UP | KEY_DOWN | KEY_LEFT | KEY_RIGHT)) {
+				if (held & KEY_UP) {
+					offset = std::max((s64)offset - 0x1000, 0ll);
+				} else if (held & KEY_DOWN) {
+					offset = std::min(offset + 0x1000, maxSize);
+				} else if (held & KEY_LEFT) {
+					offset = std::max((s64)offset - 0x10000, 0ll);
+				} else if (held & KEY_RIGHT) {
+					offset = std::min(offset + 0x10000, maxSize);
+				}
+			} else if (held & KEY_UP) {
 				if(offset > 8)
 					offset -= 8;
-				else
-					offset = 0;
 			} else if (held & KEY_DOWN) {
-				if(offset < fileSize - 8 * 23)
+				if(offset < fileSize - 8 * maxLines)
 					offset += 8;
-				else
-					offset = fileSize - 8 * 23;
 			} else if (held & KEY_LEFT) {
-				if(offset > 8 * 23)
-					offset -= 8 * 23;
-				else
-					offset = 0;
+				offset = std::max((s64)offset - 8 * maxLines, 0ll);
 			} else if (held & KEY_RIGHT) {
-				if(offset < fileSize - 8 * 23)
-					offset += 8 * 23;
-				else
-					offset = fileSize - 8 * 23;
+				offset = std::min(offset + 8 * maxLines, maxSize);
 			} else if (pressed & KEY_A) {
 				mode = 1;
 			} else if (pressed & KEY_B) {
-				return;
+				break;
 			} else if(pressed & KEY_Y) {
-				offset = jumpToOffset(offset, fileSize);
+				offset = std::min(jumpToOffset(offset), maxSize);
 				consoleClear();
 			}
 		} else if(mode == 1) {
@@ -139,27 +166,28 @@ void hexEditor(const char *path) {
 					cursorPosition -= 8;
 				else if(offset > 8)
 					offset -= 8;
-				else
-					offset = 0;
 			} else if (held & KEY_DOWN) {
 				if(cursorPosition < 8 * 22)
 					cursorPosition += 8;
-				else if(offset < fileSize - 8 * 23)
+				else if(offset < fileSize - 8 * maxLines)
 					offset += 8;
-				else
-					offset = fileSize - 8 * 23;
+				cursorPosition = std::min(cursorPosition, (u8)(fileSize - offset - 1));
 			} else if (held & KEY_LEFT) {
 				if(cursorPosition > 0)
 					cursorPosition--;
 			} else if (held & KEY_RIGHT) {
-				if(cursorPosition < 8 * 23 - 1)
-					cursorPosition++;
+				if(cursorPosition < 8 * maxLines - 1)
+					cursorPosition = std::min((u8)(cursorPosition + 1), (u8)(fileSize - offset - 1));
 			} else if (pressed & KEY_A) {
 				mode = 2;
+				consoleSelect(&bottomConsoleBG);
+				printf("\x1B[%d;%dH\x1B[%dm\2\2", 1 + cursorPosition / 8, 5 + (cursorPosition % 8 * 2) + (cursorPosition % 8 / 4), 31);
+				printf("\x1B[%d;%dH\x1B[%dm\2", 1 + cursorPosition / 8, 23 + cursorPosition % 8, 31);
+				consoleSelect(&bottomConsole);
 			} else if (pressed & KEY_B) {
 				mode = 0;
 			} else if(pressed & KEY_Y) {
-				offset = jumpToOffset(offset, fileSize);
+				offset = std::min(jumpToOffset(offset), maxSize);
 				consoleClear();
 			}
 		} else if(mode == 2) {
@@ -175,9 +203,23 @@ void hexEditor(const char *path) {
 				mode = 1;
 				fseek(file, offset + cursorPosition, SEEK_SET);
 				fwrite(data + cursorPosition, 1, 1, file);
+
+				consoleSelect(&bottomConsoleBG);
+				printf("\x1B[%d;%dH\x1B[%dm\2\2", 1 + cursorPosition / 8, 5 + (cursorPosition % 8 * 2) + (cursorPosition % 8 / 4), 30);
+				printf("\x1B[%d;%dH\x1B[%dm\2", 1 + cursorPosition / 8, 23 + cursorPosition % 8, 30);
+				consoleSelect(&bottomConsole);
 			}
 		}
 	}
 
 	fclose(file);
+
+	// Restore color palette
+	BG_PALETTE_SUB[0x1F] = 0x000F;
+	BG_PALETTE_SUB[0x2F] = 0x01E0;
+	BG_PALETTE_SUB[0x3F] = 0x3339;
+	BG_PALETTE_SUB[0x7F] = 0x656A;
+
+	consoleSelect(&bottomConsoleBG);
+	consoleClear();
 }

--- a/arm9/source/hexEditor.cpp
+++ b/arm9/source/hexEditor.cpp
@@ -59,10 +59,8 @@ void hexEditor(const char *path, int drive) {
 
 	FILE *file = fopen(path, drive < 4 ? "rb+" : "rb");
 
-	if(!file) {
-		nocashMessage("test");
+	if(!file)
 		return;
-	}
 
 	consoleClear();
 

--- a/arm9/source/hexEditor.cpp
+++ b/arm9/source/hexEditor.cpp
@@ -20,8 +20,8 @@ u32 jumpToOffset(u32 offset) {
 	while(1) {
 		printf("\x1B[9;6H\x1B[47m-------------------");
 		printf("\x1B[10;8H\x1B[47mJump to Offset");
-		printf("\x1B[12;11H\x1B[37m%08lx", offset);
-		printf("\x1B[12;%dH\x1B[41m%lx", 17 - cursorPosition, (offset >> ((cursorPosition + 1) * 4)) & 0xF);
+		printf("\x1B[12;11H\x1B[37m%08lX", offset);
+		printf("\x1B[12;%dH\x1B[41m%lX", 17 - cursorPosition, (offset >> ((cursorPosition + 1) * 4)) & 0xF);
 		printf("\x1B[13;6H\x1B[47m-------------------");
 
 		consoleSelect(&topConsole);
@@ -92,7 +92,7 @@ void hexEditor(const char *path, int drive) {
 
 		printf("\x1B[0;11H\x1B[30mHex Editor");
 
-		printf("\x1B[0;0H\x1B[30m%04lx", offset >> 0x10);
+		printf("\x1B[0;0H\x1B[30m%04lX", offset >> 0x10);
 
 		if(mode < 2) {
 			fseek(file, offset, SEEK_SET);
@@ -101,11 +101,11 @@ void hexEditor(const char *path, int drive) {
 		}
 
 		for(int i = 0; i < maxLines; i++) {
-			printf("\x1B[%d;0H\x1B[37m%04lx", i + 1, (offset + i * 8) & 0xFFFF);
+			printf("\x1B[%d;0H\x1B[37m%04lX", i + 1, (offset + i * 8) & 0xFFFF);
 			for(int j = 0; j < 4; j++)
-				printf("\x1B[%d;%dH\x1B[%dm%02x", i + 1, 5 + (j * 2), (mode > 0 && i * 8 + j == cursorPosition) ? (mode > 1 ? 30 : 31) : (offset + i * 8 + j >= fileSize ? 38 : 32 + (j % 2)), data[i * 8 + j]);
+				printf("\x1B[%d;%dH\x1B[%dm%02X", i + 1, 5 + (j * 2), (mode > 0 && i * 8 + j == cursorPosition) ? (mode > 1 ? 30 : 31) : (offset + i * 8 + j >= fileSize ? 38 : 32 + (j % 2)), data[i * 8 + j]);
 			for(int j = 0; j < 4; j++)
-				printf("\x1B[%d;%dH\x1B[%dm%02x", i + 1, 14 + (j * 2), (mode > 0 && i * 8 + 4 + j == cursorPosition) ? (mode > 1 ? 30 : 31) : (offset + i * 8 + 4 + j >= fileSize ? 38 : 32 + (j % 2)), data[i * 8 + 4 + j]);
+				printf("\x1B[%d;%dH\x1B[%dm%02X", i + 1, 14 + (j * 2), (mode > 0 && i * 8 + 4 + j == cursorPosition) ? (mode > 1 ? 30 : 31) : (offset + i * 8 + 4 + j >= fileSize ? 38 : 32 + (j % 2)), data[i * 8 + 4 + j]);
 			char line[9] = {0};
 			for(int j = 0; j < 8; j++) {
 				char c = data[i * 8 + j];

--- a/arm9/source/hexEditor.h
+++ b/arm9/source/hexEditor.h
@@ -1,6 +1,6 @@
 #ifndef HEX_EDITOR_H
 #define HEX_EDITOR_H
 
-void hexEditor(const char *path);
+void hexEditor(const char *path, int drive);
 
 #endif

--- a/arm9/source/hexEditor.h
+++ b/arm9/source/hexEditor.h
@@ -1,0 +1,6 @@
+#ifndef HEX_EDITOR_H
+#define HEX_EDITOR_H
+
+void hexEditor(const char *path);
+
+#endif


### PR DESCRIPTION
This adds a hex editor, based on the nds-bootstrap RAM viewer.

TODO:
- [x] Viewing, Editing, Jumping to addresses
- [x] Make the colors look decent
- [x] Make sure nothing lets you write beyond the file and such
- [x] Maybe searching

I noticed the GM9 hex editor is <kbd>Right</kbd> to increase by 0x10 and <kbd>Left</kbd> to decrease by 0x10, do y'all think that's better? Currently this does the opposite as when doing the nds-bootstrap one I thought left side of the byte, left to increase, but I suppose right makes more sense to increase.

I'm fine either way, but if y'all think it should be swapped then nds-bootstrap should probably be swapped too for consistency.