### PR TITLE
Fix fix_ndsheader.py being broken in Python 2

### DIFF
--- a/fix_ndsheader.py
+++ b/fix_ndsheader.py
@@ -49,7 +49,7 @@ def getBytes(e):
 		try:
 			return e.encode('ascii')
 		except:
-			print("ERROR: " + e) ;
+			print("ERROR: {}".format(e))
 #
 # CRC16 MODULE
 #
@@ -116,7 +116,7 @@ def skipUntilAddress(f_in,f_out, caddr, taddr):
 	f_out.write(chunk)
 
 def writeBlankuntilAddress(f_out, caddr, taddr):
-	f_out.write(bytes([0])*(taddr-caddr))
+	f_out.write(b"\x00"*(taddr-caddr))
 
 fname=args.file
 
@@ -403,21 +403,21 @@ else:
 # Fix srlSignedHeader
 if not args.read:
 	srlSignedHeader=srlSignedHeader._replace(
-		arm7Sha1Hmac=				bytes([255])*20,
-		arm9WithSecAreaSha1Hmac=	bytes([255])*20,
-		bannerSha1Hmac=				bytes([255])*20,
-		signature=					bytes([255])*128
+		arm7Sha1Hmac=				b'\xff'*20,
+		arm9WithSecAreaSha1Hmac=	b'\xff'*20,
+		bannerSha1Hmac=				b'\xff'*20,
+		signature=					b'\xff'*128
 		)
 	if "dsi" in args.mode :
 		srlSignedHeader=srlSignedHeader._replace(
-			arm7Sha1Hmac=				bytes([255])*20,
-			arm7iSha1Hmac=				bytes([255])*20,
-			arm9Sha1Hmac=				bytes([255])*20,
-			arm9WithSecAreaSha1Hmac=	bytes([255])*20,
-			arm9iSha1Hmac=				bytes([255])*20,
-			bannerSha1Hmac=				bytes([255])*20,
-			digestMasterSha1Hmac=		bytes([255])*20,
-			signature=					bytes([255])*128
+			arm7Sha1Hmac=				b'\xff'*20,
+			arm7iSha1Hmac=				b'\xff'*20,
+			arm9Sha1Hmac=				b'\xff'*20,
+			arm9WithSecAreaSha1Hmac=	b'\xff'*20,
+			arm9iSha1Hmac=				b'\xff'*20,
+			bannerSha1Hmac=				b'\xff'*20,
+			digestMasterSha1Hmac=		b'\xff'*20,
+			signature=					b'\xff'*128
 			)
 if args.verbose or args.read:
 	pprint(dict(srlSignedHeader._asdict()))
@@ -482,7 +482,7 @@ if not args.read:
 	filew.write(data1)
 	filew.write(data2)
 	filew.write(data3[0:0xC80])
-	filew.write(bytes([255])*16*8)
+	filew.write(b'\xff'*16*8)
 	writeBlankuntilAddress(filew,0x1000,0x4000)
 	
 	if arm9Footer.nitrocode != 0xDEC00621:


### PR DESCRIPTION
Changes `bytes([255])` to `b'\xff'` (and same to similar things) since `bytes([255])` is `'[255]'` in Python 2 instead of the correct `'\xff'`, and this also works in Python 3
