### PR TITLE
Use safer EEPROM save size check

### DIFF
--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -51,18 +51,30 @@ uint32 cardEepromGetSizeFixed() {
 	if(type == 1)
 		return 512;
 	if(type == 2) {
-		u32 buf1,buf2,buf3 = 0x54536554; // "TeST"
+		u32 buf1,buf2,buf3 = 0x54534554; // "TEST"
 		// Save the first word of the EEPROM
 		cardReadEeprom(0,(u8*)&buf1,4,type);
 
-		// Write "TeST" to it
+		// Write "TEST" to it
 		cardWriteEeprom(0,(u8*)&buf3,4,type);
 
 		// Loop until the EEPROM mirrors and the first word shows up again
 		int size = 8192;
 		while (1) {
 			cardReadEeprom(size,(u8*)&buf2,4,type);
-			if ( buf2 == buf3 ) break;
+			// Check if it matches, if so check again with another value to ensure no false positives
+			if (buf2 == buf3) {
+				u32 buf4 = 0x74736574; // "test"
+				// Write "test" to the first word
+				cardWriteEeprom(0,(u8*)&buf4,4,type);
+
+				// Check if it still matches
+				cardReadEeprom(size,(u8*)&buf2,4,type);
+				if (buf2 == buf4) break;
+
+				// False match, write "TEST" back and keep going
+				cardWriteEeprom(0,(u8*)&buf3,4,type);
+			}
 			size += 8192;
 		}
 


### PR DESCRIPTION
Changes the EEPROM size check from just testing for "TeST" to checking for "TEST" then if that passes checking again for "test" so that even if there happens to be a match on one of the values at a mod 8192 location in the save it'll still work since it's impossible to match both.

It's such a rare chance I didn't bother worrying about it before but since I've made something that fixes it now might as well use it.