### PR TITLE
Add missing `break;` in switch case

### DIFF
--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -385,6 +385,7 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 					break;
 				} case FileOperation::hexEdit: {
 					hexEditor(entry->name.c_str(), currentDrive);
+					break;
 				} case FileOperation::calculateSHA1: {
 					iprintf("\x1b[2J");
 					iprintf("Calculating SHA1 hash of:\n%s\n", entry->name.c_str());


### PR DESCRIPTION
Adds a missing `break;` in the file operation switch case to fix it calculating the file's checksum immediately after exiting the hex editor.