### PR TITLE
Add trimming existing NDS ROMs

### DIFF
--- a/arm9/source/fileOperations.cpp
+++ b/arm9/source/fileOperations.cpp
@@ -7,6 +7,7 @@
 
 #include "date.h"
 #include "file_browse.h"
+#include "ndsheaderbanner.h"
 
 #define copyBufSize 0x8000
 #define shaChunkSize 0x10000
@@ -100,6 +101,26 @@ bool calculateSHA1(const char *fileName, u8 *sha1)
 	swiSHA1Final(sha1, &ctx);
 	free(buf);
 	return true;
+}
+
+int trimNds(const char *fileName)
+{
+	FILE *file = fopen(fileName, "rb");
+	if(file) {
+		sNDSHeaderExt ndsCardHeader;
+
+		fread(&ndsCardHeader, 1, sizeof(ndsCardHeader), file);
+		fclose(file);
+
+		u32 romSize = (isDSiMode() && (ndsCardHeader.unitCode != 0) && (ndsCardHeader.twlRomSize > 0))
+						? ndsCardHeader.twlRomSize : ndsCardHeader.romSize + 0x88;
+
+		truncate(fileName, romSize);
+
+		return romSize;
+	}
+
+	return -1;
 }
 
 void dirCopy(DirEntry* entry, int i, const char *destinationPath, const char *sourcePath) {

--- a/arm9/source/fileOperations.h
+++ b/arm9/source/fileOperations.h
@@ -24,6 +24,7 @@ extern void printBytesAlign(int bytes);
 
 extern off_t getFileSize(const char *fileName);
 extern bool calculateSHA1(const char *fileName, u8 *sha1);
+extern int trimNds(const char *fileName);
 extern int fcopy(const char *sourcePath, const char *destinationPath);
 void changeFileAttribs(DirEntry* entry);
 

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -228,6 +228,8 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 			printf("   Mount NitroFS\n");
 			assignedOp[++maxCursors] = FileOperation::ndsInfo;
 			printf("   Show NDS file info\n");
+			assignedOp[++maxCursors] = FileOperation::trimNds;
+			printf("   Trim NDS file\n");
 		}
 		else if(extension(entry->name, {"sav", "sav1", "sav2", "sav3", "sav4", "sav5", "sav6", "sav7", "sav8", "sav9"}))
 		{
@@ -381,6 +383,9 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 					break;
 				} case FileOperation::ndsInfo: {
 					ndsInfo(entry->name.c_str());
+					break;
+				} case FileOperation::trimNds: {
+					entry->size = trimNds(entry->name.c_str());
 					break;
 				} case FileOperation::showInfo: {
 					changeFileAttribs(entry);

--- a/arm9/source/file_browse.h
+++ b/arm9/source/file_browse.h
@@ -38,6 +38,8 @@ enum class FileOperation {
 	bootFile,
 	bootstrapFile,
 	mountNitroFS,
+	ndsInfo,
+	trimNds,
 	mountImg,
 	restoreSave,
 	showInfo,
@@ -45,7 +47,6 @@ enum class FileOperation {
 	copyFatOut,
 	calculateSHA1,
 	hexEdit,
-	ndsInfo,
 };
 
 bool extension(const std::string &filename, const std::vector<std::string> &extensions);


### PR DESCRIPTION
Adds trimming existing NDS ROMs, simply select "Trim NDS file" from the menu on selecting one.

---

Tested on my DSi (K) from Unlaunch with Mario Kart DS, LEGO Indiana Jones: The Original Adventures, and Drawn to Life: The Next Chapter