### PR TITLE
Fix dumping saves from ID 0xC22017

### DIFF
--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -117,8 +117,15 @@ uint32 cardEepromGetSizeFixed() {
 
 		if ( ((id >> 16) & 0xff) == 0xC2 ) { // Macronix
 			
-			if (device == 0x2211)
+			switch(device) {
+
+			case 0x2211:
 				return 128*1024;		//	1Mbit(128KByte) - MX25L1021E
+				break;
+			case 0x2017:
+				return 8*1024*1024;		//	64Mbit(8 meg)
+				break;
+			}
 		}
 
 		if (id == 0xffffff) {


### PR DESCRIPTION
Fixes dumping saves from cards with the card EEPROM ID 0xC22017, an 8 MByte chip used in Art Academy (Spain) or at least FerozElMejor's copy.