### PR TITLE
Fix restoring to ID 0xC22017 cards

### DIFF
--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -39,6 +39,7 @@ int cardEepromGetTypeFixed(void) {
 //---------------------------------------------------------------------------------
 // https://github.com/devkitPro/libnds/blob/master/source/common/cardEeprom.c#L88
 // with type 2 fixed if the first word and another % 8192 location are 0x00000000
+// and type 3 with ID 0xC22017 added
 uint32 cardEepromGetSizeFixed() {
 //---------------------------------------------------------------------------------
 
@@ -133,6 +134,20 @@ uint32 cardEepromGetSizeFixed() {
 	}
 
 	return 0;
+}
+
+//---------------------------------------------------------------------------------
+// https://github.com/devkitPro/libnds/blob/master/source/common/cardEeprom.c#L263
+// but using our fixed size function
+//---------------------------------------------------------------------------------
+void cardEepromChipEraseFixed(void) {
+//---------------------------------------------------------------------------------
+	int sz, sector;
+	sz=cardEepromGetSizeFixed();
+
+	for ( sector = 0; sector < sz; sector+=0x10000) {
+		cardEepromSectorErase(sector);
+	}
 }
 
 void ndsCardSaveDump(const char* filename) {
@@ -257,7 +272,7 @@ void ndsCardSaveRestore(const char *filename) {
 				if(auxspi)
 					auxspi_erase(card_type);
 				else
-					cardEepromChipErase();
+					cardEepromChipEraseFixed();
 			}
 			if(auxspi){
 				buffer = new unsigned char[LEN];


### PR DESCRIPTION
Part two of #106, this fixes not erasing the whole EEPROM when restoring to ID 0xC22017 cards, shoulda tested better before the last PR. 😅