### PR TITLE
Fix NAND cart dumping

### DIFF
--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -309,7 +309,11 @@ void ndsCardSaveRestore(const char *filename) {
 			u32 saveSize = cardNandGetSaveSize();
 
 			if(saveSize == 0) {
-				dumpFailMsg(true);
+				font->print(0, 0, false, "Unable to restore the save.");
+				font->update(false);
+				for (int i = 0; i < 60 * 2; i++) {
+					swiWaitForVBlank();
+				}
 				return;
 			}
 
@@ -327,22 +331,21 @@ void ndsCardSaveRestore(const char *filename) {
 
 			u32 currentSize = saveSize;
 			if (in) {
-
 				font->print(0, 4, false, "Progress:");
 				font->print(0, 5, false, "[");
 				font->print(-1, 5, false, "]");
-				for (u32 src = 0; src < saveSize; src += 0x8000) {
+				for (u32 dest = 0; dest < saveSize; dest += 0x8000) {
 					// Print time
 					font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
 					font->update(true);
 
-					font->print((src / (saveSize / (SCREEN_COLS - 2))) + 1, 5, false, "=");
-					font->printf(0, 6, false, Alignment::left, Palette::white, "%d/%d Bytes", src, saveSize);
+					font->print((dest / (saveSize / (SCREEN_COLS - 2))) + 1, 5, false, "=");
+					font->printf(0, 6, false, Alignment::left, Palette::white, "%d/%d Bytes", dest, saveSize);
 					font->update(false);
 
 					fread(copyBuf, 1, 0x8000, in);
 					for (u32 i = 0; i < 0x8000; i += 0x800) {
-						cardWriteNand(copyBuf + i, cardNandRwStart + src + i);
+						cardWriteNand(copyBuf + i, cardNandRwStart + dest + i);
 					}
 					currentSize -= 0x8000;
 				}

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -194,7 +194,7 @@ u32 cardNandGetSaveSize(void) {
 		case 0x00524F55: // 'UOR'
 			return 16 << 20; // 16MByte - WarioWare D.I.Y.
 		case 0x004B5355: // 'USK'
-			return 82 << 20; // 82MByte - Face Training
+			return 64 << 20; // 64MByte - Face Training
 	}
 
 	return 0;

--- a/arm9/source/ndsheaderbanner.h
+++ b/arm9/source/ndsheaderbanner.h
@@ -85,7 +85,10 @@ typedef struct {
 	u32 romSize;				//!< total size of the ROM.
 
 	u32 headerSize;				//!< ROM header size.
-	u32 zeros88[14];
+	u32 zeros88[3];
+	u16 nandRomEnd;				//!< ROM region end for NAND games.
+	u16 nandRwStart;			//!< RW region start for NAND games.
+	u32 zeros98[10];
 	u8 gbaLogo[156];			//!< Nintendo logo needed for booting the game.
 	u16 logoCRC16;				//!< Nintendo Logo Checksum, CRC-16.
 	u16 headerCRC16;			//!< header checksum, CRC-16.

--- a/arm9/source/read_card.c
+++ b/arm9/source/read_card.c
@@ -547,7 +547,7 @@ void cardRead (u32 src, void* dest, bool nandSave)
 		portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_BLK_SIZE(1),
 		dest, 0x200/sizeof(u32));
 
-	if (src > ndsHeader->romSize) {
+	if (src > ndsHeader->romSize && !(nandSave && src >= cardNandRwStart)) {
 		switchToTwlBlowfish(ndsHeader);
 	}
 }

--- a/arm9/source/read_card.c
+++ b/arm9/source/read_card.c
@@ -533,12 +533,12 @@ void cardRead (u32 src, void* dest, bool nandSave)
 
 	if (nandChip) {
 		if ((src < cardNandRomEnd || !nandSave) && nandSection != -1) {
-			cardParamCommand(CARD_CMD_NAND_ROM_MODE, 0, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);
+			cardParamCommand(CARD_CMD_NAND_ROM_MODE, 0, portFlags | CARD_ACTIVATE | CARD_nRESET, NULL, 0);
 			nandSection = -1;
 		} else if (src >= cardNandRwStart && nandSection != (src - cardNandRwStart) / (128 << 10) && nandSave) {
 			if(nandSection != -1) // Need to switch back to ROM mode before switching to another RW section
-				cardParamCommand(CARD_CMD_NAND_ROM_MODE, 0, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);
-			cardParamCommand(CARD_CMD_NAND_RW_MODE, src, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);
+				cardParamCommand(CARD_CMD_NAND_ROM_MODE, 0, portFlags | CARD_ACTIVATE | CARD_nRESET, NULL, 0);
+			cardParamCommand(CARD_CMD_NAND_RW_MODE, src, portFlags | CARD_ACTIVATE | CARD_nRESET, NULL, 0);
 			nandSection = (src - cardNandRwStart) / (128 << 10);
 		}
 	}
@@ -560,24 +560,24 @@ void cardWriteNand (void* src, u32 dest)
 
 	if (nandSection != (dest - cardNandRwStart) / (128 << 10)) {
 		if(nandSection != -1) // Need to switch back to ROM mode before switching to another RW section
-			cardParamCommand(CARD_CMD_NAND_ROM_MODE, 0, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);
-		cardParamCommand(CARD_CMD_NAND_RW_MODE, dest, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);
+			cardParamCommand(CARD_CMD_NAND_ROM_MODE, 0, portFlags | CARD_ACTIVATE | CARD_nRESET, NULL, 0);
+		cardParamCommand(CARD_CMD_NAND_RW_MODE, dest, portFlags | CARD_ACTIVATE | CARD_nRESET, NULL, 0);
 		nandSection = (dest - cardNandRwStart) / (128 << 10);
 	}
 
-	cardParamCommand(CARD_CMD_NAND_WRITE_ENABLE, 0, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);
+	cardParamCommand(CARD_CMD_NAND_WRITE_ENABLE, 0, portFlags | CARD_ACTIVATE | CARD_nRESET, NULL, 0);
 
 	const u8 cmdData[8] = {0, 0, 0, dest, dest >> 8, dest >> 16, dest >> 24, CARD_CMD_NAND_WRITE_BUFFER};
 	for (int i = 0; i < 4; i++) {
 		cardPolledTransferWrite(portFlags | CARD_ACTIVATE | CARD_WR | CARD_nRESET | CARD_BLK_SIZE(1), src + (i * 0x200), 0x200 / sizeof(u32), cmdData);
 	}
 
-	cardParamCommand(CARD_CMD_NAND_COMMIT_BUFFER, 0, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);
+	cardParamCommand(CARD_CMD_NAND_COMMIT_BUFFER, 0, portFlags | CARD_ACTIVATE | CARD_nRESET, NULL, 0);
 
 	u32 status;
 	do {
-		cardParamCommand(CARD_CMD_NAND_READ_STATUS, 0, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW | CARD_BLK_SIZE(7), &status, 1);
+		cardParamCommand(CARD_CMD_NAND_READ_STATUS, 0, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_BLK_SIZE(7), &status, 1);
 	} while((status & BIT(5)) == 0);
 
-	cardParamCommand(CARD_CMD_NAND_DISCARD_BUFFER, 0, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);
+	cardParamCommand(CARD_CMD_NAND_DISCARD_BUFFER, 0, portFlags | CARD_ACTIVATE | CARD_nRESET, NULL, 0);
 }

--- a/arm9/source/read_card.c
+++ b/arm9/source/read_card.c
@@ -535,7 +535,7 @@ void cardRead (u32 src, void* dest, bool nandSave)
 		if ((src < cardNandRomEnd || !nandSave) && nandSection != -1) {
 			cardParamCommand(CARD_CMD_NAND_ROM_MODE, 0, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);
 			nandSection = -1;
-		} else if (src >= cardNandRwStart && nandSection != (src - cardNandRwStart) / (128 << 10)) {
+		} else if (src >= cardNandRwStart && nandSection != (src - cardNandRwStart) / (128 << 10) && nandSave) {
 			if(nandSection != -1) // Need to switch back to ROM mode before switching to another RW section
 				cardParamCommand(CARD_CMD_NAND_ROM_MODE, 0, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);
 			cardParamCommand(CARD_CMD_NAND_RW_MODE, src, portFlags | CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW, NULL, 0);

--- a/arm9/source/read_card.c
+++ b/arm9/source/read_card.c
@@ -72,8 +72,7 @@ static u32 secureArea[CARD_SECURE_AREA_SIZE/sizeof(u32)] = {0};
 static const u8 cardSeedBytes[] = {0xE8, 0x4D, 0x5A, 0xB1, 0x17, 0x8F, 0x99, 0xD5};
 
 static u32 getRandomNumber(void) {
-	return 4;	// chosen by fair dice roll.
-				// guaranteed to be random.
+	return rand();
 }
 
 static void decryptSecureArea (u32 gameCode, u32* secureArea, int iCardDevice)

--- a/arm9/source/read_card.h
+++ b/arm9/source/read_card.h
@@ -36,9 +36,14 @@
 extern "C" {
 #endif
 
+extern u32 cardNandRomEnd;
+extern u32 cardNandRwStart;
+
 int cardInit (sNDSHeaderExt* ndsHeader);
 
-void cardRead (u32 src, void* dest);
+void cardRead (u32 src, void* dest, bool nandSave);
+
+void cardWriteNand (void* src, u32 dest);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Completely untested at the moment, I don't have a NAND cart to test with

TODO:
- [x] Fix NAND cart ROM dumping
- [x] Fix NAND cart save dumping
   - [x] Safety checks and such, I don't think all `-1` type are NAND, etc
- [x] Fix NAND cart save restoring
   - Haven't started on this yet, will do so after reading works
- Face Training ROM works but save dumping is broken, save writing is untested
- Fixes #96 
