### PR TITLE
Fix freezing on boot on  flashcard & getting GBA cart info

### DIFF
--- a/arm7/source/main.c
+++ b/arm7/source/main.c
@@ -124,10 +124,12 @@ int main() {
 	setPowerButtonCB(powerButtonCB);
 
 	// Check for 3DS
-	u8 byteBak = i2cReadRegister(0x4A, 0x71);
-	i2cWriteRegister(0x4A, 0x71, 0xD2);
-	fifoSendValue32(FIFO_USER_05, i2cReadRegister(0x4A, 0x71));
-	i2cWriteRegister(0x4A, 0x71, byteBak);
+	if(isDSiMode()) {
+		u8 byteBak = i2cReadRegister(0x4A, 0x71);
+		i2cWriteRegister(0x4A, 0x71, 0xD2);
+		fifoSendValue32(FIFO_USER_05, i2cReadRegister(0x4A, 0x71));
+		i2cWriteRegister(0x4A, 0x71, byteBak);
+	}
 
 	if (isDSiMode() /*|| ((REG_SCFG_EXT & BIT(17)) && (REG_SCFG_EXT & BIT(18)))*/) {
 		/*for (int i = 0; i < 8; i++) {

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -688,11 +688,11 @@ void gbaCartDump(void) {
 			mkdir("fat:/gm9i/out", 0777);
 		}
 		char gbaHeaderGameTitle[13] = "\0";
-		tonccpy(&gbaHeaderGameTitle, (u8*)(0x080000A0), 12);
+		tonccpy(gbaHeaderGameTitle, (u8*)(0x080000A0), 12);
 		char gbaHeaderGameCode[5] = "\0";
-		tonccpy(&gbaHeaderGameCode, (u8*)(0x080000AC), 4);
+		tonccpy(gbaHeaderGameCode, (u8*)(0x080000AC), 4);
 		char gbaHeaderMakerCode[3] = "\0";
-		tonccpy(&gbaHeaderMakerCode, (u8*)(0x080000B0), 2);
+		tonccpy(gbaHeaderMakerCode, (u8*)(0x080000B0), 2);
 		if (gbaHeaderGameTitle[0] == 0 || gbaHeaderGameTitle[0] == 0xFF) {
 			sprintf(gbaHeaderGameTitle, "NO-TITLE");
 		} else {

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -688,11 +688,11 @@ void gbaCartDump(void) {
 			mkdir("fat:/gm9i/out", 0777);
 		}
 		char gbaHeaderGameTitle[13] = "\0";
-		tonccpy((u8*)(0x080000A0), &gbaHeaderGameTitle, 12);
+		tonccpy(&gbaHeaderGameTitle, (u8*)(0x080000A0), 12);
 		char gbaHeaderGameCode[5] = "\0";
-		tonccpy((u8*)(0x080000AC), &gbaHeaderGameCode, 4);
+		tonccpy(&gbaHeaderGameCode, (u8*)(0x080000AC), 4);
 		char gbaHeaderMakerCode[3] = "\0";
-		tonccpy((u8*)(0x080000B0), &gbaHeaderMakerCode, 2);
+		tonccpy(&gbaHeaderMakerCode, (u8*)(0x080000B0), 2);
 		if (gbaHeaderGameTitle[0] == 0 || gbaHeaderGameTitle[0] == 0xFF) {
 			sprintf(gbaHeaderGameTitle, "NO-TITLE");
 		} else {


### PR DESCRIPTION
- Fixes ARM7 freezing when trying to check if on a 3DS on a flashcard
- Fixes trying to tonccpy *to* the GBA cart instead of *from* it to get the title and such

---

- Tested on DSTT on a DS Lite (J)