### PR TITLE
Fix GBA EEPROM saves

### DIFF
--- a/arm7/include/gba.h
+++ b/arm7/include/gba.h
@@ -1,0 +1,9 @@
+#define GBA_H
+#ifdef GBA_H
+
+#include <nds/ndstypes.h>
+
+void readEeprom(u8 *dst, u32 src, u32 len);
+void writeEeprom(u32 dst, u8 *src, u32 len);
+
+#endif // GBA_H

--- a/arm7/source/gba.c
+++ b/arm7/source/gba.c
@@ -1,0 +1,123 @@
+#include "gba.h"
+
+#include <nds/dma.h>
+#include <nds/memory.h>
+#include <nds/fifocommon.h>
+#include <string.h>
+
+#define EEPROM_ADDRESS (0x09FFFF00)
+#define REG_EEPROM *(vu16 *)(EEPROM_ADDRESS)
+#define DMA3_CR_H *(vu16 *)(0x040000DE)
+
+void EEPROM_SendPacket(u16 *packet, int size)
+{
+	REG_EXMEMSTAT = (REG_EXMEMSTAT & 0xFFE3) | 0x000C;
+	DMA3_SRC = (u32)packet;
+	DMA3_DEST = EEPROM_ADDRESS;
+	DMA3_CR = 0x80000000 + size;
+	while((DMA3_CR_H & 0x8000) != 0);
+}
+
+void EEPROM_ReceivePacket(u16 *packet, int size)
+{
+	REG_EXMEMSTAT = (REG_EXMEMSTAT & 0xFFE3) | 0x000C;
+	DMA3_SRC = EEPROM_ADDRESS;
+	DMA3_DEST = (u32)packet;
+	DMA3_CR = 0x80000000 + size;
+	while((DMA3_CR_H & 0x8000) != 0);
+}
+
+void gbaEepromRead8Bytes(u8 *out, u16 addr, bool short_addr)
+{
+	u16 packet[68];
+
+	memset(packet, 0, 68 * 2);
+
+	// Read request
+	packet[0] = 1;
+	packet[1] = 1;
+
+	// 6 or 14 bytes eeprom address (MSB first)
+	for(int i = 2, shift = (short_addr ? 5 : 13); i < (short_addr ? 8 : 16); i++, shift--) {
+		packet[i] = (addr >> shift) & 1;
+	}
+
+	// End of request
+	packet[short_addr ? 8 : 16] = 0;
+
+	// Do transfers
+	EEPROM_SendPacket(packet, short_addr ? 9 : 17);
+	memset(packet, 0, 68 * 2);
+	EEPROM_ReceivePacket(packet, 68);
+
+	// Extract data
+	u16 *in_pos = &packet[4];
+	for(int byte = 7; byte >= 0; --byte) {
+		u8 out_byte = 0;
+		for(int bit = 7; bit >= 0; --bit) {
+			// out_byte += (*in_pos++) << bit;
+			out_byte += ((*in_pos++) & 1) << bit;
+		}
+		*out++ = out_byte;
+	}
+}
+
+void gbaEepromWrite8Bytes(u8 *in, u16 addr, bool short_addr)
+{
+	u16 packet_length = short_addr ? 73 : 81;
+	u16 packet[packet_length];
+
+	memset(packet, 0, packet_length * 2);
+
+	// Write request
+	packet[0] = 1;
+	packet[1] = 0;
+
+	// 6 or 14 bytes eeprom address (MSB first)
+	for(int i = 2, shift = (short_addr ? 5 : 13); i < (short_addr ? 8 : 16); i++, shift--) {
+		packet[i] = (addr >> shift) & 1;
+	}
+
+	// Extract data
+	u16 *out_pos = &packet[short_addr ? 8 : 16];
+	for(int byte = 7; byte >= 0; --byte) {
+		u8 in_byte = *in++;
+		for(int bit = 7; bit >= 0; --bit) {
+			*out_pos++ = (in_byte >> bit) & 1;
+		}
+	}
+
+	// End of request
+	packet[packet_length - 1] = 0;
+
+	// Do transfers
+	EEPROM_SendPacket(packet, packet_length);
+
+	// Wait for EEPROM to finish (should timeout after 10 ms)
+	while((REG_EEPROM & 1) == 0);
+}
+
+void readEeprom(u8 *dst, u32 src, u32 len)
+{
+	int start, end;
+	start = src >> 3;
+	end = (src + len) >> 3;
+	u8 buffer[8];
+	for (int j = start; j < end; j++) {
+		gbaEepromRead8Bytes(buffer, j, len == 0x200);
+		fifoSendDatamsg(FIFO_USER_02, 8, buffer);
+	}
+}
+
+void writeEeprom(u32 dst, u8 *src, u32 len)
+{
+	int start, end;
+	start = dst >> 3;
+	end = (dst + len) >> 3;
+	u8 *ptr = src;
+	for (int j = start; j < end; j++, ptr += 8) {
+		gbaEepromWrite8Bytes(ptr, j, len == 0x200);
+	}
+
+	fifoSendValue32(FIFO_USER_02, 0x454E4F44 /* 'DONE' */);
+}

--- a/arm7/source/main.c
+++ b/arm7/source/main.c
@@ -30,6 +30,8 @@
 #include <nds.h>
 #include <string.h>
 
+#include "gba.h"
+
 void my_installSystemFIFO(void);
 void my_sdmmc_get_cid(int devicenumber, u32 *cid);
 
@@ -177,6 +179,19 @@ int main() {
 		}
 		*(u8*)(0x2FFFD08) = ((*(vu32*)(0x400481C) & BIT(3)) || !(*(vu32*)(0x400481C) & BIT(5)));	// Set if there's no SD inserted
 		resyncClock();
+
+		// Dump EEPROM save
+		if(fifoCheckAddress(FIFO_USER_01)) {
+			switch(fifoGetValue32(FIFO_USER_01)) {
+				case 0x44414552: // 'READ'
+					readEeprom((u8 *)fifoGetAddress(FIFO_USER_01), fifoGetValue32(FIFO_USER_01), fifoGetValue32(FIFO_USER_01));
+					break;
+				case 0x54495257: // 'WRITE'
+					writeEeprom(fifoGetValue32(FIFO_USER_01), (u8 *)fifoGetAddress(FIFO_USER_01), fifoGetValue32(FIFO_USER_01));
+					break;
+			}
+		}
+
 		swiWaitForVBlank();
 	}
 	return 0;

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -758,19 +758,6 @@ void gbaCartSaveDump(const char *filename) {
 	font->update(false);
 
 	saveTypeGBA type = gbaGetSaveType();
-
-	if(type == SAVE_GBA_EEPROM_05 || type == SAVE_GBA_EEPROM_8) {
-		font->clear(false);
-		font->print(0, 0, false, "EEPROM saves are not currently supported!\n\nUse GBA Backup Tool to backup/restore this game's save.\nhttps://gamebrew.org/wiki/GBA_Backup_Tool\n\n(<A> OK)");
-		font->update(false);
-
-		do {
-			scanKeys();
-			swiWaitForVBlank();
-		} while(!(keysDown() & KEY_A));
-		return;
-	}
-
 	u32 size = gbaGetSaveSize(type);
 	if(size == 0)
 		return;

--- a/arm9/source/gba.h
+++ b/arm9/source/gba.h
@@ -1,7 +1,7 @@
 /*
  * savegame_manager: a tool to backup and restore savegames from Nintendo
  *  DS cartridges. Nintendo DS and all derivative names are trademarks
- *  by Nintendo. EZFlash 3-in-1 is a trademark by EZFlash.
+ *  by Nintendo.
  *
  * gba.h: header file for gba.cpp
  *
@@ -46,4 +46,4 @@ bool gbaWriteSave(u32 dst, u8 *src, u32 len, saveTypeGBA type);
 bool gbaFormatSave(saveTypeGBA type);
 
 
-#endif // __SLOT2_H__
+#endif // __GBA_H__


### PR DESCRIPTION
- Fixes dumping/restoring EEPROM GBA saves
   - They can only be accessed by ARM7 was the issue
- Also a bit of cleanup to the dumping error messages

Big thanks to nocash, I sent him an email asking if he could figure out how GBA Backup Tool was doing it and he noticed that it was doing the EEPROM reading on ARM7.