### PR TITLE
Fix GBA FLASH 64 KB writing 2 banks

### DIFF
--- a/arm9/source/gba.cpp
+++ b/arm9/source/gba.cpp
@@ -299,7 +299,6 @@ bool gbaWriteSave(u32 dst, u8 *src, u32 len, saveTypeGBA type)
 	case SAVE_GBA_FLASH_128:
 		// FLASH - must be opend by register magic, erased and then rewritten
 		// FIXME: currently, you can only write "all or nothing"
-		nbanks = 2;
 		for (int j = 0; j < nbanks; j++) {
 			*(vu8*)0x0a005555 = 0xaa;
 			swiDelay(10);


### PR DESCRIPTION
Before it was setting nbanks to 2 in the 128 KB case, which the 64 KB case falls through to, which overrode the 1 bank set by the 64 KB case. It's already correctly setting it to 2 when initializing the variable so just removes that line.

This didn't seem to be actually causing any problems, I assume the too high writes were just failing, but still better to do it correctly.