### PR TITLE
Fix unmounting drives not responding immediately

### DIFF
--- a/arm9/source/driveMenu.cpp
+++ b/arm9/source/driveMenu.cpp
@@ -267,7 +267,7 @@ void driveMenu (void) {
 					break;
 				}
 			}
-		} while (!(pressed & (KEY_UP | KEY_DOWN | KEY_LEFT | KEY_RIGHT | KEY_A | KEY_R | KEY_START
+		} while (!(pressed & (KEY_UP | KEY_DOWN | KEY_LEFT | KEY_RIGHT | KEY_A | KEY_B | KEY_X | KEY_L | KEY_START
 #ifdef SCREENSWAP
 				| KEY_TOUCH
 #endif

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -650,11 +650,7 @@ std::string browseForFile (void) {
 			if (REG_SCFG_MC != stored_SCFG_MC) {
 				break;
 			}
-
-			if ((held & KEY_R) && (pressed & KEY_L)) {
-				break;
-			}
-		} while (!pressed);
+		} while (!(pressed & ~(KEY_R | KEY_TOUCH | KEY_LID)));
 
 		if (isDSiMode() && !pressed && currentDrive == Drive::flashcard && REG_SCFG_MC == 0x11 && flashcardMounted) {
 			flashcardUnmount();


### PR DESCRIPTION
- Fixes there being a delay before it would notice you holding the buttons to unmount a drive
   - For some reason it now Guru errors on unmounting the SD, not sure why or when that started... It never worked after unmounting to begin with though so not a major regression
- Fixes #120