### PR TITLE
Fix remounting SD card

### DIFF
--- a/arm7/source/my_sdmmc.c
+++ b/arm7/source/my_sdmmc.c
@@ -594,7 +594,7 @@ int my_sdmmc_nand_startup() {
 //---------------------------------------------------------------------------------
 int my_sdmmc_sd_startup() {
 //---------------------------------------------------------------------------------
-    my_sdmmc_controller_init(false);
+    my_sdmmc_controller_init(true);
     return my_sdmmc_sdcard_init();
 }
 

--- a/arm9/source/driveMenu.cpp
+++ b/arm9/source/driveMenu.cpp
@@ -152,9 +152,7 @@ void dm_drawBottomScreen(void) {
 	font->print(0, row--, false, STR_START_START_MENU);
 
 	if (sdMountedDone) {
-		if (isRegularDS || sdMounted) {
-			font->print(0, row--, false, sdMounted ? STR_UNMOUNT_SDCARD : STR_REMOUNT_SDCARD);
-		}
+		font->print(0, row--, false, sdMounted ? STR_UNMOUNT_SDCARD : STR_REMOUNT_SDCARD);
 	} else {
 		font->print(0, row--, false, flashcardMounted ? STR_UNMOUNT_FLASHCARD : STR_REMOUNT_FLASHCARD);
 	}
@@ -401,7 +399,7 @@ void driveMenu (void) {
 					currentDrive = Drive::sdCard;
 					chdir("sd:/");
 					sdUnmount();
-				} else if (isRegularDS) {
+				} else {
 					sdMounted = sdMount();
 				}
 			} else {

--- a/arm9/source/driveOperations.cpp
+++ b/arm9/source/driveOperations.cpp
@@ -101,11 +101,9 @@ const char* getDrivePath(void) {
 }
 
 void fixLabel(char* label) {
-	for (int i = 0; i < 12; i++) {
-		if (((label[i] == ' ') && (label[i+1] == ' ') && (label[i+2] == ' '))
-		|| ((label[i] == ' ') && (label[i+1] == ' '))
-		|| (label[i] == ' ')) {
-			label[i] = '\0';
+	for (int i = strlen(label) - 1; i >= 0; i--) {
+		if(label[i] != ' ') {
+			label[i + 1] = '\0';
 			break;
 		}
 	}
@@ -160,7 +158,7 @@ bool sdMount(void) {
 	if (sdFound()) {
 		sdMountedDone = true;
 		fatGetVolumeLabel("sd", sdLabel);
-		fixLabel(&sdLabel[0]);
+		fixLabel(sdLabel);
 		struct statvfs st;
 		if (statvfs("sd:/", &st) == 0) {
 			sdSize = st.f_bsize * st.f_blocks;
@@ -288,7 +286,7 @@ TWL_CODE bool twl_flashcardMount(void) {
 
 		if (flashcardFound()) {
 			fatGetVolumeLabel("fat", fatLabel);
-			fixLabel(&fatLabel[0]);
+			fixLabel(fatLabel);
 			struct statvfs st;
 			if (statvfs("fat:/", &st) == 0) {
 				fatSize = st.f_bsize * st.f_blocks;
@@ -304,7 +302,7 @@ bool flashcardMount(void) {
 		fatInitDefault();
 		if (flashcardFound()) {
 			fatGetVolumeLabel("fat", fatLabel);
-			fixLabel(&fatLabel[0]);
+			fixLabel(fatLabel);
 			struct statvfs st;
 			if (statvfs("fat:/", &st) == 0) {
 				fatSize = st.f_bsize * st.f_blocks;
@@ -349,7 +347,7 @@ bool imgMount(const char* imgName) {
 	fatMountSimple("img", &io_img);
 	if (imgFound()) {
 		fatGetVolumeLabel("img", imgLabel);
-		fixLabel(&imgLabel[0]);
+		fixLabel(imgLabel);
 		struct statvfs st;
 		if (statvfs("img:/", &st) == 0) {
 			imgSize = st.f_bsize * st.f_blocks;


### PR DESCRIPTION
- Fixes remounting the SD card
   - The ARM7 change is all that was actually needed (ARM9 changes are just not hiding the option), it wasn't doing a force_init which meant it'd just... not reinit it
   - Fixes #3 
- Also fixes the SD label being cut off on the first space instead of the last one