### PR TITLE
Improve AK2i secondary drive mounting (?)

### DIFF
--- a/arm9/source/driveOperations.cpp
+++ b/arm9/source/driveOperations.cpp
@@ -265,25 +265,25 @@ TWL_CODE bool twl_flashcardMount(void) {
 		// Read a DLDI driver specific to the cart
 		if (!memcmp(gameid, "ASMA", 4)) {
 			io_dldi_data = dldiLoadFromBin(r4tf_dldi);
-			fatMountSimple("fat", dldiGetInternal());      
+			fatMountSimple("fat", &io_dldi_data->ioInterface);      
 		} else if (!memcmp(gamename, "TOP TF/SD DS", 12) || !memcmp(gameid, "A76E", 4)) {
 			io_dldi_data = dldiLoadFromBin(tt_sd_dldi);
-			fatMountSimple("fat", dldiGetInternal());
+			fatMountSimple("fat", &io_dldi_data->ioInterface);
  		} else /*if (!memcmp(gamename, "PASS", 4) && !memcmp(gameid, "ASME", 4)) {
 			io_dldi_data = dldiLoadFromBin(CycloEvo_dldi);
-			fatMountSimple("fat", dldiGetInternal());
+			fatMountSimple("fat", &io_dldi_data->ioInterface);
 		} else*/ if (!memcmp(gamename, "D!S!XTREME", 10) && !memcmp(gameid, "AYIE", 4)) {
 			io_dldi_data = dldiLoadFromBin(dsx_dldi);
-			fatMountSimple("fat", dldiGetInternal()); 
+			fatMountSimple("fat", &io_dldi_data->ioInterface); 
         } else if (!memcmp(gamename, "QMATETRIAL", 9) || !memcmp(gamename, "R4DSULTRA", 9)) {
 			io_dldi_data = dldiLoadFromBin(r4idsn_sd_dldi);
-			fatMountSimple("fat", dldiGetInternal());
+			fatMountSimple("fat", &io_dldi_data->ioInterface);
 		} else if (!memcmp(gameid, "ACEK", 4) || !memcmp(gameid, "YCEP", 4) || !memcmp(gameid, "AHZH", 4) || !memcmp(gameid, "CHPJ", 4) || !memcmp(gameid, "ADLP", 4)) {
 			io_dldi_data = dldiLoadFromBin(ak2_sd_dldi);
-			fatMountSimple("fat", dldiGetInternal());
+			fatMountSimple("fat", &io_dldi_data->ioInterface);
 		} /*else if (!memcmp(gameid, "ALXX", 4)) {
 			io_dldi_data = dldiLoadFromBin(dstwo_dldi);
-			fatMountSimple("fat", dldiGetInternal());
+			fatMountSimple("fat", &io_dldi_data->ioInterface);
 		}*/
 
 		if (flashcardFound()) {
@@ -424,7 +424,7 @@ bool driveWritable(Drive drive) {
 		case Drive::sdCard:
 			return __my_io_dsisd()->features & FEATURE_MEDIUM_CANWRITE;
 		case Drive::flashcard:
-			return dldiGetInternal()->features & FEATURE_MEDIUM_CANWRITE;
+			return io_dldi_data->ioInterface.features & FEATURE_MEDIUM_CANWRITE;
 		case Drive::ramDrive:
 			return io_ram_drive.features & FEATURE_MEDIUM_CANWRITE;
 		case Drive::nand:

--- a/arm9/source/driveOperations.cpp
+++ b/arm9/source/driveOperations.cpp
@@ -226,6 +226,15 @@ TWL_CODE bool UpdateCardInfo(char* gameid, char* gamename) {
 	return true;
 }
 
+const DISC_INTERFACE *dldiGet(void) {
+	if(io_dldi_data->ioInterface.features & FEATURE_SLOT_GBA)
+		sysSetCartOwner(BUS_OWNER_ARM9);
+	if(io_dldi_data->ioInterface.features & FEATURE_SLOT_NDS)
+		sysSetCardOwner(BUS_OWNER_ARM9);
+
+	return &io_dldi_data->ioInterface;
+}
+
 TWL_CODE bool twl_flashcardMount(void) {
 	if (REG_SCFG_MC != 0x11) {
 		sysSetCardOwner (BUS_OWNER_ARM9);
@@ -265,25 +274,25 @@ TWL_CODE bool twl_flashcardMount(void) {
 		// Read a DLDI driver specific to the cart
 		if (!memcmp(gameid, "ASMA", 4)) {
 			io_dldi_data = dldiLoadFromBin(r4tf_dldi);
-			fatMountSimple("fat", &io_dldi_data->ioInterface);      
+			fatMountSimple("fat", dldiGet());
 		} else if (!memcmp(gamename, "TOP TF/SD DS", 12) || !memcmp(gameid, "A76E", 4)) {
 			io_dldi_data = dldiLoadFromBin(tt_sd_dldi);
-			fatMountSimple("fat", &io_dldi_data->ioInterface);
+			fatMountSimple("fat", dldiGet());
  		} else /*if (!memcmp(gamename, "PASS", 4) && !memcmp(gameid, "ASME", 4)) {
 			io_dldi_data = dldiLoadFromBin(CycloEvo_dldi);
-			fatMountSimple("fat", &io_dldi_data->ioInterface);
+			fatMountSimple("fat", dldiGet());
 		} else*/ if (!memcmp(gamename, "D!S!XTREME", 10) && !memcmp(gameid, "AYIE", 4)) {
 			io_dldi_data = dldiLoadFromBin(dsx_dldi);
-			fatMountSimple("fat", &io_dldi_data->ioInterface); 
+			fatMountSimple("fat", dldiGet()); 
         } else if (!memcmp(gamename, "QMATETRIAL", 9) || !memcmp(gamename, "R4DSULTRA", 9)) {
 			io_dldi_data = dldiLoadFromBin(r4idsn_sd_dldi);
-			fatMountSimple("fat", &io_dldi_data->ioInterface);
+			fatMountSimple("fat", dldiGet());
 		} else if (!memcmp(gameid, "ACEK", 4) || !memcmp(gameid, "YCEP", 4) || !memcmp(gameid, "AHZH", 4) || !memcmp(gameid, "CHPJ", 4) || !memcmp(gameid, "ADLP", 4)) {
 			io_dldi_data = dldiLoadFromBin(ak2_sd_dldi);
-			fatMountSimple("fat", &io_dldi_data->ioInterface);
+			fatMountSimple("fat", dldiGet());
 		} /*else if (!memcmp(gameid, "ALXX", 4)) {
 			io_dldi_data = dldiLoadFromBin(dstwo_dldi);
-			fatMountSimple("fat", &io_dldi_data->ioInterface);
+			fatMountSimple("fat", dldiGet());
 		}*/
 
 		if (flashcardFound()) {
@@ -424,7 +433,7 @@ bool driveWritable(Drive drive) {
 		case Drive::sdCard:
 			return __my_io_dsisd()->features & FEATURE_MEDIUM_CANWRITE;
 		case Drive::flashcard:
-			return io_dldi_data->ioInterface.features & FEATURE_MEDIUM_CANWRITE;
+			return dldiGet()->features & FEATURE_MEDIUM_CANWRITE;
 		case Drive::ramDrive:
 			return io_ram_drive.features & FEATURE_MEDIUM_CANWRITE;
 		case Drive::nand:


### PR DESCRIPTION
Was messing around and finally figured out why my AK2i couldn't mount in GM9i, it doesn't work with dldiGetInternal() only if you use the loaded DLDI directly in fat_mount_simple.

Looking at the file history I see that this is how it used to be done, but was changed for some reason... Why was that? Does this break something else? That's why I'm not sure this is actually an improvement or not, testing is definitely required.

I've tested from TWiLight and Unlaunch (and loading from AK2i and DSTT to ensure it still works normally) and this seems fine, but maybe it breaks other cards?