### PR TITLE
Clear cart info on eject outside of drive menu and detect ramdrive eject

### DIFF
--- a/arm9/source/driveMenu.cpp
+++ b/arm9/source/driveMenu.cpp
@@ -274,10 +274,6 @@ void driveMenu (void) {
 
 		// Power saving loop. Only poll the keys once per frame and sleep the CPU if there is nothing else to do
 		do {
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-	
 			scanKeys();
 			pressed = keysDownRepeat();
 			held = keysHeld();

--- a/arm9/source/driveMenu.cpp
+++ b/arm9/source/driveMenu.cpp
@@ -60,8 +60,8 @@ bool flashcardMountSkipped = true;
 static bool flashcardMountRan = true;
 static int dmCursorPosition = 0;
 static std::vector<DriveMenuOperation> dmOperations;
-static char romTitle[2][13] = {0};
-static u32 romSize[2], romSizeTrimmed;
+char romTitle[2][13] = {0};
+u32 romSize[2], romSizeTrimmed;
 
 static u8 gbaFixedValue = 0;
 static u8 stored_SCFG_MC = 0;

--- a/arm9/source/driveMenu.cpp
+++ b/arm9/source/driveMenu.cpp
@@ -287,6 +287,12 @@ void driveMenu (void) {
 				if (*(u8*)(0x080000B2) != gbaFixedValue) {
 					break;
 				}
+				if(driveRemoved(Drive::ramDrive)) {
+					currentDrive = Drive::ramDrive;
+					chdir("ram:/");
+					ramdriveUnmount();
+					break;
+				}
 			} else if (isDSiMode()) {
 				if ((REG_SCFG_MC != stored_SCFG_MC) || (flashcardMounted && driveRemoved(Drive::flashcard))) {
 					break;

--- a/arm9/source/driveMenu.h
+++ b/arm9/source/driveMenu.h
@@ -5,6 +5,8 @@
 #include <vector>
 
 extern bool flashcardMountSkipped;
+extern char romTitle[2][13];
+extern u32 romSize[2], romSizeTrimmed;
 
 extern void driveMenu (void);
 

--- a/arm9/source/driveOperations.cpp
+++ b/arm9/source/driveOperations.cpp
@@ -408,6 +408,17 @@ void ramdriveMount(bool ram32MB) {
 	}
 }
 
+void ramdriveUnmount(void) {
+	if(imgMounted && imgCurrentDrive == Drive::ramDrive)
+		imgUnmount();
+	if(nitroMounted && nitroCurrentDrive == Drive::ramDrive)
+		nitroUnmount();
+
+	fatUnmount("ram");
+	ramdSize = 0;
+	ramdriveMounted = false;
+}
+
 void nitroUnmount(void) {
 	if(imgMounted && imgCurrentDrive == Drive::nitroFS)
 		imgUnmount();
@@ -470,7 +481,7 @@ bool driveRemoved(Drive drive) {
 		case Drive::flashcard:
 			return isDSiMode() ? REG_SCFG_MC & BIT(0) : !flashcardMounted;
 		case Drive::ramDrive:
-			return !ramdriveMounted;
+			return (isDSiMode() || REG_SCFG_EXT != 0) ? !ramdriveMounted : !(*(u16*)(0x020000C0) != 0 || *(vu16*)(0x08240000) == 1);
 		case Drive::nand:
 			return !nandMounted;
 		case Drive::nitroFS:

--- a/arm9/source/driveOperations.h
+++ b/arm9/source/driveOperations.h
@@ -50,6 +50,7 @@ extern void sdUnmount(void);
 extern bool flashcardMount(void);
 extern void flashcardUnmount(void);
 extern void ramdriveMount(bool ram32MB);
+extern void ramdriveUnmount(void);
 extern void nitroUnmount(void);
 extern bool imgMount(const char* imgName, bool dsiwareSave);
 extern void imgUnmount(void);

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -93,10 +93,6 @@ DumpOption dumpMenu(std::vector<DumpOption> allowedOptions, const char *dumpName
 
 		// Power saving loop. Only poll the keys once per frame and sleep the CPU if there is nothing else to do
 		do {
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			scanKeys();
 			pressed = keysDownRepeat();
 			held = keysHeld();
@@ -147,10 +143,6 @@ void dumpFailMsg(std::string_view msg) {
 
 	u16 pressed;
 	do {
-		// Print time
-		font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-		font->update(true);
-
 		scanKeys();
 		pressed = keysDown();
 		swiWaitForVBlank();
@@ -331,10 +323,6 @@ bool writeToGbaSave(const char* fileName, u8* buffer, u32 size) {
 
 		u16 pressed;
 		do {
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			swiWaitForVBlank();
 			scanKeys();
 			pressed = keysDownRepeat();
@@ -448,10 +436,6 @@ bool readFromGbaCart() {
 
 			if(*(u8*)(0x080000B2) == 0x96) {
 				while(*(u8*)(0x080000B2) == 0x96) {
-					// Print time
-					font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-					font->update(true);
-
 					swiWaitForVBlank();
 					scanKeys();
 
@@ -462,10 +446,6 @@ bool readFromGbaCart() {
 				}
 			}
 			while(*(u8*)(0x080000B2) != 0x96) {
-				// Print time
-				font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-				font->update(true);
-
 				swiWaitForVBlank();
 				scanKeys();
 
@@ -519,10 +499,6 @@ void ndsCardSaveDump(const char* filename) {
 			font->print(0, 5, false, "[");
 			font->print(-1, 5, false, "]");
 			for (u32 src = 0; src < saveSize; src += 0x8000) {
-				// Print time
-				font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-				font->update(true);
-
 				font->print((src / (saveSize / (SCREEN_COLS - 2))) + 1, 5, false, "=");
 				font->printf(0, 6, false, Alignment::left, Palette::white, STR_N_OF_N_BYTES.c_str(), src, saveSize);
 				font->update(false);
@@ -584,10 +560,6 @@ void ndsCardSaveRestore(const char *filename) {
 	// Power saving loop. Only poll the keys once per frame and sleep the CPU if there is nothing else to do
 	u16 pressed;
 	do {
-		// Print time
-		font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-		font->update(true);
-
 		scanKeys();
 		pressed = keysDown();
 		swiWaitForVBlank();
@@ -627,10 +599,6 @@ void ndsCardSaveRestore(const char *filename) {
 				font->print(0, 5, false, "[");
 				font->print(-1, 5, false, "]");
 				for (u32 dest = 0; dest < saveSize; dest += 0x8000) {
-					// Print time
-					font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-					font->update(true);
-
 					font->print((dest / (saveSize / (SCREEN_COLS - 2))) + 1, 5, false, "=");
 					font->printf(0, 6, false, Alignment::left, Palette::white, STR_N_OF_N_BYTES.c_str(), dest, saveSize);
 					font->update(false);
@@ -671,10 +639,6 @@ void ndsCardSaveRestore(const char *filename) {
 
 					// Power saving loop. Only poll the keys once per frame and sleep the CPU if there is nothing else to do
 					do {
-						// Print time
-						font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-						font->update(true);
-
 						scanKeys();
 						pressed = keysDown();
 						swiWaitForVBlank();
@@ -785,10 +749,6 @@ void ndsCardDump(void) {
 		font->update(false);
 
 		while (true) {
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			scanKeys();
 			pressed = keysDownRepeat();
 			swiWaitForVBlank();
@@ -910,10 +870,6 @@ void ndsCardDump(void) {
 			font->print(0, 5, false, "[");
 			font->print(-1, 5, false, "]");
 			for (u32 src = 0; src < romSize; src += 0x8000) {
-				// Print time
-				font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-				font->update(true);
-
 				font->print((src / (romSize / (SCREEN_COLS - 2))) + 1, 5, false, "=");
 				font->printf(0, 6, false, Alignment::left, Palette::white, STR_N_OF_N_BYTES.c_str(), src, romSize);
 				font->update(false);
@@ -1003,10 +959,6 @@ void gbaCartSaveRestore(const char *filename) {
 	// Power saving loop. Only poll the keys once per frame and sleep the CPU if there is nothing else to do
 	u16 pressed;
 	do {
-		// Print time
-		font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-		font->update(true);
-
 		scanKeys();
 		pressed = keysDownRepeat();
 		swiWaitForVBlank();
@@ -1187,10 +1139,6 @@ void gbaCartDump(void) {
 			font->print(0, 5, false, "[");
 			font->print(-1, 5, false, "]");
 			for (u32 src = 0; src < romSize; src += 0x8000) {
-				// Print time
-				font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-				font->update(true);
-
 				font->print((src / (romSize / (SCREEN_COLS - 2))) + 1, 5, false, "=");
 				font->printf(0, 6, false, Alignment::left, Palette::white, STR_N_OF_N_BYTES.c_str(), src, romSize);
 				font->update(false);
@@ -1219,10 +1167,6 @@ void gbaCartDump(void) {
 				font->print(0, 5, false, "[");
 				font->print(-1, 5, false, "]");
 				for (size_t i = 0x02000000; i < 0x04000000; i += 0x1000) {
-					// Print time
-					font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-					font->update(true);
-
 					font->print((i / (0x04000000 / (SCREEN_COLS - 2))) + 1, 5, false, "=");
 					font->printf(0, 7, false, Alignment::left, Palette::white, STR_N_OF_N_BYTES.c_str(), i - 0x02000000, 0x04000000 - 0x02000000);
 					font->update(false);

--- a/arm9/source/fileOperations.cpp
+++ b/arm9/source/fileOperations.cpp
@@ -5,7 +5,6 @@
 #include <dirent.h>
 #include <vector>
 
-#include "date.h"
 #include "file_browse.h"
 #include "font.h"
 #include "ndsheaderbanner.h"
@@ -197,10 +196,6 @@ int fcopy(const char *sourcePath, const char *destinationPath) {
 				break;
 			}
 
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			font->print((offset / (fsize / (SCREEN_COLS - 2))) + 1, 1, false, "=");
 			font->printf(0, 2, false, Alignment::left, Palette::white, STR_N_OF_N_BYTES.c_str(), (int)offset, (int)fsize);
 			font->update(false);
@@ -257,10 +252,6 @@ void changeFileAttribs(const DirEntry *entry) {
 
 		// Power saving loop. Only poll the keys once per frame and sleep the CPU if there is nothing else to do
 		do {
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			scanKeys();
 			held = keysHeld();
 			pressed = keysDown();

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -287,10 +287,6 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 
 		// Power saving loop. Only poll the keys once per frame and sleep the CPU if there is nothing else to do
 		do {
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			scanKeys();
 			pressed = keysDownRepeat();
 			held = keysHeld();
@@ -450,10 +446,6 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 					// Power saving loop. Only poll the keys once per frame and sleep the CPU if there is nothing else to do
 					int pressed;
 					do {
-						// Print time
-						font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-						font->update(true);
-
 						scanKeys();
 						pressed = keysDownRepeat();
 						swiWaitForVBlank();
@@ -514,10 +506,6 @@ bool fileBrowse_paste(char dest[256]) {
 
 		// Power saving loop. Only poll the keys once per frame and sleep the CPU if there is nothing else to do
 		do {
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			scanKeys();
 			pressed = keysDownRepeat();
 			swiWaitForVBlank();
@@ -660,10 +648,6 @@ std::string browseForFile (void) {
 
 		// Power saving loop. Only poll the keys once per frame and sleep the CPU if there is nothing else to do
 		do {
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			scanKeys();
 			pressed = keysDownRepeat();
 			held = keysHeld();
@@ -768,10 +752,6 @@ std::string browseForFile (void) {
 
 		// Rename file/folder
 		if ((held & KEY_R) && (pressed & KEY_X) && (entry->name != ".." && driveWritable(currentDrive))) {
-			// Clear time
-			font->print(-1, 0, true, "     ", Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			pressed = 0;
 
 			std::string newName = kbdGetString(STR_RENAME_TO, -1, entry->name);
@@ -819,10 +799,6 @@ std::string browseForFile (void) {
 			font->update(false);
 
 			while (true) {
-				// Print time
-				font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-				font->update(true);
-
 				scanKeys();
 				pressed = keysDownRepeat();
 				swiWaitForVBlank();
@@ -851,10 +827,6 @@ std::string browseForFile (void) {
 						pressed = 0;
 
 						while (!(pressed & KEY_A)) {
-							// Print time
-							font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-							font->update(true);
-
 							scanKeys();
 							pressed = keysDown();
 							swiWaitForVBlank();
@@ -887,10 +859,6 @@ std::string browseForFile (void) {
 
 		// Create new folder
 		if ((held & KEY_R) && (pressed & KEY_Y) && driveWritable(currentDrive)) {
-			// Clear time
-			font->print(-1, 0, true, "     ", Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			pressed = 0;
 
 			std::string newName = kbdGetString(STR_NAME_FOR_NEW_FOLDER);
@@ -923,10 +891,6 @@ std::string browseForFile (void) {
 			entry->selected = select;
 			while(held & KEY_L) {
 				do {
-					// Print time
-					font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-					font->update(true);
-
 					scanKeys();
 					pressed = keysDownRepeat();
 					held = keysHeld();

--- a/arm9/source/hexEditor.cpp
+++ b/arm9/source/hexEditor.cpp
@@ -1,6 +1,5 @@
 #include "hexEditor.h"
 
-#include "date.h"
 #include "file_browse.h"
 #include "font.h"
 #include "keyboard.h"
@@ -31,10 +30,6 @@ u32 jumpToOffset(u32 offset) {
 			scanKeys();
 			pressed = keysDown();
 			held = keysDownRepeat();
-
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
 		} while(!held);
 
 		if(held & KEY_UP) {
@@ -72,10 +67,6 @@ u32 search(u32 offset, FILE *file) {
 			scanKeys();
 			pressed = keysDown();
 			held = keysDownRepeat();
-
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
 		} while(!held);
 
 		if(held & (KEY_UP | KEY_DOWN)) {
@@ -115,10 +106,6 @@ u32 search(u32 offset, FILE *file) {
 				scanKeys();
 				pressed = keysDown();
 				held = keysDownRepeat();
-
-				// Print time
-				font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-				font->update(true);
 			} while(!held);
 
 			if(held & KEY_UP) {
@@ -207,10 +194,6 @@ u32 search(u32 offset, FILE *file) {
 	do {
 		swiWaitForVBlank();
 		scanKeys();
-
-		// Print time
-		font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-		font->update(true);
 	} while(!keysDown());
 
 	return offset;
@@ -284,10 +267,6 @@ void hexEditor(const char *path, Drive drive) {
 			scanKeys();
 			pressed = keysDown();
 			held = keysDownRepeat();
-
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
 
 			if(driveRemoved(currentDrive))
 				return;

--- a/arm9/source/keyboard.cpp
+++ b/arm9/source/keyboard.cpp
@@ -1,5 +1,4 @@
 #include "keyboard.h"
-#include "date.h"
 #include "font.h"
 #include "language.h"
 
@@ -31,10 +30,6 @@ std::string kbdGetString(std::string label, int maxSize, std::string oldStr) {
 		font->update(false);
 
 		do {
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			scanKeys();
 			pressed = keysDownRepeat();
 			key = keyboardUpdate();

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -70,6 +70,22 @@ void stop (void) {
 	}
 }
 
+//---------------------------------------------------------------------------------
+void vblankHandler (void) {
+//---------------------------------------------------------------------------------
+	// Check if NDS cart ejected
+	if(isDSiMode() && (REG_SCFG_MC & BIT(0)) && romTitle[0][0] != '\0') {
+		romTitle[0][0] = '\0';
+		romSizeTrimmed = romSize[0] = 0;
+	}
+
+	// Check if GBA cart ejected
+	if(isRegularDS && *(u8*)(0x080000B2) != 0x96 && romTitle[1][0] != '\0') {
+		romTitle[1][0] = '\0';
+		romSize[1] = 0;
+	}
+}
+
 char filePath[PATH_MAX];
 
 //---------------------------------------------------------------------------------
@@ -222,6 +238,9 @@ int main(int argc, char **argv) {
 	langInit(false);
 
 	keysSetRepeat(25,5);
+
+	// Enable vblank handler
+	irqSet(IRQ_VBLANK, vblankHandler);
 
 	appInited = true;
 

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -31,6 +31,7 @@
 
 #include "nds_loader_arm9.h"
 #include "config.h"
+#include "date.h"
 #include "driveMenu.h"
 #include "driveOperations.h"
 #include "file_browse.h"
@@ -57,6 +58,7 @@ bool arm7SCFGLocked = false;
 bool isRegularDS = true;
 bool is3DS = false;
 int ownNitroFSMounted;
+std::string prevTime;
 
 bool applaunch = false;
 
@@ -83,6 +85,16 @@ void vblankHandler (void) {
 	if(isRegularDS && *(u8*)(0x080000B2) != 0x96 && romTitle[1][0] != '\0') {
 		romTitle[1][0] = '\0';
 		romSize[1] = 0;
+	}
+
+	// Print time
+	std::string time = RetTime();
+	if(time != prevTime) {
+		prevTime = time;
+		if(font) {
+			font->print(-1, 0, true, time, Alignment::right, Palette::blackGreen);
+			font->update(true);
+		}
 	}
 }
 
@@ -238,6 +250,9 @@ int main(int argc, char **argv) {
 	langInit(false);
 
 	keysSetRepeat(25,5);
+
+	// Top bar
+	font->printf(0, 0, true, Alignment::left, Palette::blackGreen, "%*c", 256 / font->width(), ' ');
 
 	// Enable vblank handler
 	irqSet(IRQ_VBLANK, vblankHandler);

--- a/arm9/source/ndsInfo.cpp
+++ b/arm9/source/ndsInfo.cpp
@@ -1,6 +1,5 @@
 #include "ndsInfo.h"
 
-#include "date.h"
 #include "font.h"
 #include "language.h"
 #include "screenshot.h"
@@ -93,10 +92,6 @@ void ndsInfo(const char *path) {
 			scanKeys();
 			pressed = keysDown();
 			held = keysDownRepeat();
-
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
 
 			if(iconAnimation[animationFrame] && animationFrame < 0x40) {
 				if(frameDelay < (iconAnimation[animationFrame] & 0xFF) - 1) {

--- a/arm9/source/screenshot.cpp
+++ b/arm9/source/screenshot.cpp
@@ -1,10 +1,10 @@
 #include "screenshot.h"
 
 #include "bmp.h"
+#include "date.h"
 #include "driveOperations.h"
 #include "file_browse.h"
 #include "font.h"
-#include "date.h"
 
 #include <dirent.h>
 #include <fat.h>

--- a/arm9/source/startMenu.cpp
+++ b/arm9/source/startMenu.cpp
@@ -1,7 +1,6 @@
 #include "startMenu.h"
 
 #include "config.h"
-#include "date.h"
 #include "font.h"
 #include "language.h"
 #include "main.h"
@@ -111,10 +110,6 @@ void languageMenu() {
 		font->update(false);
 
 		do {
-			// Print time
-			font->print(-1, 0, true, RetTime(), Alignment::right, Palette::blackGreen);
-			font->update(true);
-
 			scanKeys();
 			swiWaitForVBlank();
 		} while (!(keysDownRepeat() & KEY_A));


### PR DESCRIPTION
- Fixes the cart info not being updated if you swap carts in any menu besides the drive menu
- Detects and unmounts the RAM drive if ejected on regular DS
- Fixes a couple other issues with RAM drives
- Updates time in a vblank handler so as to not need time update handling in every single loop