### PR TITLE
Revert to malloc for allocating ramdrive on DSi

### DIFF
--- a/arm9/source/ramd.c
+++ b/arm9/source/ramd.c
@@ -20,7 +20,7 @@ const u16 bootSectorSignature = 0xAA55;
 
 bool ramd_startup() {
 	if(isDSiMode() || REG_SCFG_EXT != 0) {
-		ramdLoc = (u8*)calloc(0x6000 * SECTOR_SIZE, 1);
+		ramdLoc = (u8*)malloc(0x6000 * SECTOR_SIZE);
 	} else {
 		ramdLoc = (u8*)calloc(0x8 * SECTOR_SIZE, 1);
 		toncset(ramdLocMep, 0, (ramdSectors - 0x8) * SECTOR_SIZE); // Fill MEP with 00 to avoid displaying weird files


### PR DESCRIPTION
For some reason zeroing the RAM is breaking NAND mounting, dunno why as you can fill it up 100% and NAND still works fine but this fixes it and I've only seen a fake file in the DSi RAM disk once