### PR TITLE
Fix failing to read flashcard if RAM drive removed

### DIFF
--- a/arm9/source/driveMenu.cpp
+++ b/arm9/source/driveMenu.cpp
@@ -283,7 +283,7 @@ void driveMenu (void) {
 				if (*(u8*)(0x080000B2) != gbaFixedValue) {
 					break;
 				}
-				if(driveRemoved(Drive::ramDrive)) {
+				if(ramdriveMounted && driveRemoved(Drive::ramDrive)) {
 					currentDrive = Drive::ramDrive;
 					chdir("ram:/");
 					ramdriveUnmount();


### PR DESCRIPTION
It was constantly trying to unmount the RAM drive if it wasn't plugged in, even if it already wasn't mounted, which due to libfat being libfat was unmounting the flashcard SD.