### PR TITLE
Improve screen swap

### DIFF
--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -97,11 +97,7 @@ DumpOption dumpMenu(std::vector<DumpOption> allowedOptions, const char *dumpName
 			pressed = keysDownRepeat();
 			held = keysHeld();
 			swiWaitForVBlank();
-		} while (!(pressed & (KEY_UP| KEY_DOWN | KEY_A | KEY_B | KEY_L))
-#ifdef SCREENSWAP
-				&& !(pressed & KEY_TOUCH)
-#endif
-				);
+		} while (!(pressed & (KEY_UP| KEY_DOWN | KEY_A | KEY_B | KEY_L)));
 
 		if (pressed & KEY_UP)
 			optionOffset--;
@@ -114,19 +110,13 @@ DumpOption dumpMenu(std::vector<DumpOption> allowedOptions, const char *dumpName
 		if (optionOffset >= (int)allowedOptions.size()) // Wrap around to top of list
 			optionOffset = 0;
 
-		if (pressed & KEY_A)
+		if (pressed & KEY_A) {
 			return allowedOptions[optionOffset];
-
-		if (pressed & KEY_B)
-			return DumpOption::none;
-
-#ifdef SCREENSWAP
-		// Swap screens
-		if (pressed & KEY_TOUCH) {
-			screenSwapped = !screenSwapped;
-			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
 		}
-#endif
+
+		if (pressed & KEY_B) {
+			return DumpOption::none;
+		}
 
 		// Make a screenshot
 		if ((held & KEY_R) && (pressed & KEY_L)) {
@@ -740,6 +730,10 @@ void ndsCardSaveRestore(const char *filename) {
 }
 
 void ndsCardDump(void) {
+#ifdef SCREENSWAP
+	lcdMainOnTop();
+#endif
+
 	u16 pressed;
 
 	font->clear(false);
@@ -758,6 +752,9 @@ void ndsCardDump(void) {
 				break;
 			}
 			if (pressed & KEY_B) {
+#ifdef SCREENSWAP
+				screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+#endif
 				return;
 			}
 		}
@@ -928,8 +925,11 @@ void ndsCardDump(void) {
 			fclose(destinationFile);
 		}
 	}
-}
 
+#ifdef SCREENSWAP
+	screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+#endif
+}
 
 void gbaCartSaveDump(const char *filename) {
 	font->clear(false);
@@ -1023,6 +1023,10 @@ void readChange(void) {
 }
 
 void gbaCartDump(void) {
+#ifdef SCREENSWAP
+	lcdMainOnTop();
+#endif
+
 	font->clear(false);
 	font->print(0, 0, false, STR_LOADING);
 	font->update(false);
@@ -1236,4 +1240,8 @@ void gbaCartDump(void) {
 			fclose(destinationFile);
 		}
 	}
+
+#ifdef SCREENSWAP
+	screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+#endif
 }

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -167,6 +167,10 @@ void showDirectoryContents(std::vector<DirEntry> &dirContents, int fileOffset, i
 }
 
 FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
+#ifdef SCREENSWAP
+	lcdMainOnTop();
+#endif
+
 	int pressed = 0, held = 0;
 	std::vector<FileOperation> operations;
 	int optionOffset = 0;
@@ -292,13 +296,13 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 			held = keysHeld();
 			swiWaitForVBlank();
 
-			if(driveRemoved(currentDrive))
-				return FileOperation::none;
-		} while (!(pressed & (KEY_UP| KEY_DOWN | KEY_A | KEY_B | KEY_L))
+			if(driveRemoved(currentDrive)) {
 #ifdef SCREENSWAP
-				&& !(pressed & KEY_TOUCH)
+				screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
 #endif
-				);
+				return FileOperation::none;
+			}
+		} while (!(pressed & (KEY_UP| KEY_DOWN | KEY_A | KEY_B | KEY_L)));
 
 		if (pressed & KEY_UP)		optionOffset -= 1;
 		if (pressed & KEY_DOWN)		optionOffset += 1;
@@ -460,18 +464,16 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 				}
 			}
 			keysDownRepeat(); // prevent unwanted key repeat
+#ifdef SCREENSWAP
+			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+#endif
 			return operations[optionOffset];
 		} else if (pressed & KEY_B) {
+#ifdef SCREENSWAP
+			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+#endif
 			return FileOperation::none;
 		}
-#ifdef SCREENSWAP
-		// Swap screens
-		else if (pressed & KEY_TOUCH) {
-			screenSwapped = !screenSwapped;
-			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-		}
-#endif
-
 		// Make a screenshot
 		else if ((held & KEY_R) && (pressed & KEY_L)) {
 			screenshot();
@@ -480,6 +482,10 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 }
 
 bool fileBrowse_paste(char dest[256]) {
+#ifdef SCREENSWAP
+	lcdMainOnTop();
+#endif
+
 	int pressed = 0;
 	int optionOffset = 0;
 
@@ -509,12 +515,7 @@ bool fileBrowse_paste(char dest[256]) {
 			scanKeys();
 			pressed = keysDownRepeat();
 			swiWaitForVBlank();
-		} while (!(pressed & KEY_UP) && !(pressed & KEY_DOWN)
-				&& !(pressed & KEY_A) && !(pressed & KEY_B)
-#ifdef SCREENSWAP
-				&& !(pressed & KEY_TOUCH)
-#endif
-				);
+		} while (!(pressed & (KEY_UP | KEY_DOWN | KEY_A | KEY_B)));
 
 		if (pressed & KEY_UP)		optionOffset -= 1;
 		if (pressed & KEY_DOWN)		optionOffset += 1;
@@ -543,18 +544,17 @@ bool fileBrowse_paste(char dest[256]) {
 			}
 			clipboardUsed = true;		// Disable clipboard restore
 			clipboardOn = false;	// Clear clipboard after copying or moving
+#ifdef SCREENSWAP
+			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+#endif
 			return true;
 		}
 		if (pressed & KEY_B) {
+#ifdef SCREENSWAP
+			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+#endif
 			return false;
 		}
-#ifdef SCREENSWAP
-		// Swap screens
-		if (pressed & KEY_TOUCH) {
-			screenSwapped = !screenSwapped;
-			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-		}
-#endif
 	}
 }
 
@@ -657,7 +657,7 @@ std::string browseForFile (void) {
 				screenMode = 0;
 				return "null";
 			}
-		} while (!(pressed & ~(KEY_R | KEY_TOUCH | KEY_LID)));
+		} while (!(pressed & ~(KEY_R | KEY_LID)));
 
 		if (pressed & KEY_UP) {
 			fileOffset--;

--- a/arm9/source/keyboard.cpp
+++ b/arm9/source/keyboard.cpp
@@ -1,11 +1,16 @@
 #include "keyboard.h"
 #include "font.h"
 #include "language.h"
+#include "main.h"
 
 #include <nds.h>
 #include <string.h>
 
 std::string kbdGetString(std::string label, int maxSize, std::string oldStr) {
+#ifdef SCREENSWAP
+	lcdMainOnTop();
+#endif
+
 	font->clear(false);
 	font->update(false);
 
@@ -34,11 +39,7 @@ std::string kbdGetString(std::string label, int maxSize, std::string oldStr) {
 			pressed = keysDownRepeat();
 			key = keyboardUpdate();
 			swiWaitForVBlank();
-		} while (!((pressed & (KEY_LEFT | KEY_RIGHT | KEY_B | KEY_START
-#ifdef SCREENSWAP
-				&& !(pressed & KEY_TOUCH)
-#endif
-				)) || (key != -1)));
+		} while (!((pressed & (KEY_LEFT | KEY_RIGHT | KEY_B | KEY_START)) || (key != -1)));
 
 		switch(key) {
 			case NOKEY:
@@ -96,6 +97,10 @@ std::string kbdGetString(std::string label, int maxSize, std::string oldStr) {
 		}
 	}
 	keyboardHide();
+
+#ifdef SCREENSWAP
+	screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+#endif
 
 	return output;
 }

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -45,7 +45,7 @@
 
 #include "gm9i_logo.h"
 
-char titleName[32] = {" "};
+char titleName[64] = {" "};
 
 int screenMode = 0;
 
@@ -115,7 +115,11 @@ int main(int argc, char **argv) {
 	
 	bool yHeld = false;
 
+#ifdef SCREENSWAP
+	sprintf(titleName, "GodMode9i (Screen Swap) %s", VER_NUMBER);
+#else
 	sprintf(titleName, "GodMode9i %s", VER_NUMBER);
+#endif
 
 	// initialize video mode
 	videoSetMode(MODE_5_2D);

--- a/arm9/source/titleManager.cpp
+++ b/arm9/source/titleManager.cpp
@@ -4,6 +4,7 @@
 #include "fileOperations.h"
 #include "font.h"
 #include "language.h"
+#include "main.h"
 #include "screenshot.h"
 
 #include <algorithm>


### PR DESCRIPTION
- Fixes screen swap not working in the file browser
- Fixes compilation error due to missing includes in a couple files
- Makes bottom screen menus automatically swap to the bottom
- Changes the version text to say `GodMode9i (Screen Swap) v#.#.#`

Build: [GodMode9i.zip](https://github.com/DS-Homebrew/GodMode9i/files/8312239/GodMode9i.zip)
 