### PR TITLE
Fix 128 KiB EEPROM saves

### DIFF
--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -527,6 +527,7 @@ void ndsCardSaveDump(const char* filename) {
 			buffer = new unsigned char[size];
 			auxspi_read_data(0, buffer, size, type, card_type);
 		} else {
+			type = cardEepromGetTypeFixed();
 			size = cardEepromGetSizeFixed();
 			buffer = new unsigned char[size];
 			cardReadEeprom(0, buffer, size, type);
@@ -665,6 +666,7 @@ void ndsCardSaveRestore(const char *filename) {
 					LEN = 1 << shift;
 					num_blocks = 1 << (size - shift);
 				} else {
+					type = cardEepromGetTypeFixed();
 					size = cardEepromGetSizeFixed();
 				}
 


### PR DESCRIPTION
Fixes 128 KiB EEPROMs having reverted to the old broken behaviour, I'm honestly not quite sure *why* this fixes it, but I just re-added the type checks later in the function and now it works. I guess for some weird reason it only works properly for these games after `auxspi_has_extra()` (didn't test what specifically, this is just a guess) or something like that? It still needs to be checked earlier as well as that's used as the NAND save check.

- Fixes #88