### PR TITLE
Change screen swap to an ini option

### DIFF
--- a/arm9/source/config.cpp
+++ b/arm9/source/config.cpp
@@ -39,6 +39,7 @@ Config::Config() {
 	sniprintf(defaultLanguagePath, sizeof(defaultLanguagePath), "nitro:/languages/%s/language.ini", getSystemLanguage());
 	_languageIniPath = ini.GetString("GODMODE9I", "LANGUAGE_INI_PATH", defaultLanguagePath);
 	_fontPath = ini.GetString("GODMODE9I", "FONT_PATH", "sd:/gm9i/font.frf");
+	_screenSwap = ini.GetInt("GODMODE9I", "SCREEN_SWAP", 0);
 
 	// If the config doesn't exist, create it
 	if(access(_configPath, F_OK) != 0)
@@ -50,6 +51,7 @@ void Config::save() {
 
 	ini.SetString("GODMODE9I", "LANGUAGE_INI_PATH", _languageIniPath);
 	ini.SetString("GODMODE9I", "FONT_PATH", _fontPath);
+	ini.SetInt("GODMODE9I", "SCREEN_SWAP", _screenSwap);
 
 	ini.SaveIniFile(_configPath);
 }

--- a/arm9/source/config.h
+++ b/arm9/source/config.h
@@ -3,11 +3,14 @@
 
 #include "inifile.h"
 
+#include <nds.h>
+
 class Config {
 	const char *_configPath;
 
 	std::string _languageIniPath;
 	std::string _fontPath;
+	bool _screenSwap;
 
 	static const char *getSystemLanguage(void);
 
@@ -21,6 +24,10 @@ public:
 	void languageIniPath(const std::string &languageIniPath) { _languageIniPath = languageIniPath; }
 
 	const std::string &fontPath(void) { return _fontPath; }
+
+	bool screenSwap(void) { return _screenSwap; }
+	void screenSwap(bool &screenSwap) { _screenSwap = screenSwap; }
+	u32 screenSwapKey(void) { return _screenSwap ? KEY_TOUCH : 0; }
 };
 
 extern Config *config;

--- a/arm9/source/driveMenu.cpp
+++ b/arm9/source/driveMenu.cpp
@@ -28,6 +28,7 @@
 #include <dirent.h>
 
 #include "main.h"
+#include "config.h"
 #include "date.h"
 #include "screenshot.h"
 #include "dumpOperations.h"
@@ -302,11 +303,7 @@ void driveMenu (void) {
 					break;
 				}
 			}
-		} while (!(pressed & (KEY_UP | KEY_DOWN | KEY_LEFT | KEY_RIGHT | KEY_A | KEY_B | KEY_X | KEY_L | KEY_START
-#ifdef SCREENSWAP
-				| KEY_TOUCH
-#endif
-		)));
+		} while (!(pressed & (KEY_UP | KEY_DOWN | KEY_LEFT | KEY_RIGHT | KEY_A | KEY_B | KEY_X | KEY_L | KEY_START | config->screenSwapKey())));
 
 		if(dmOperations.size() != 0) {
 			if (pressed & KEY_UP) {
@@ -415,13 +412,11 @@ void driveMenu (void) {
 			startMenu();
 		}
 
-#ifdef SCREENSWAP
 		// Swap screens
-		if (pressed & KEY_TOUCH) {
+		if (pressed & config->screenSwapKey()) {
 			screenSwapped = !screenSwapped;
 			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
 		}
-#endif
 
 		// Make a screenshot
 		if ((held & KEY_R) && (pressed & KEY_L)) {

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -1,6 +1,7 @@
 #include "dumpOperations.h"
 
 #include "auxspi.h"
+#include "config.h"
 #include "date.h"
 #include "driveOperations.h"
 #include "fileOperations.h"
@@ -745,9 +746,8 @@ void ndsCardSaveRestore(const char *filename) {
 }
 
 void ndsCardDump(void) {
-#ifdef SCREENSWAP
-	lcdMainOnTop();
-#endif
+	if(config->screenSwap())
+		lcdMainOnTop();
 
 	u16 pressed;
 
@@ -767,9 +767,9 @@ void ndsCardDump(void) {
 				break;
 			}
 			if (pressed & KEY_B) {
-#ifdef SCREENSWAP
-				screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-#endif
+				if(config->screenSwap())
+					screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+
 				return;
 			}
 		}
@@ -944,9 +944,8 @@ void ndsCardDump(void) {
 		}
 	}
 
-#ifdef SCREENSWAP
-	screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-#endif
+	if(config->screenSwap())
+		screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
 }
 
 void gbaCartSaveDump(const char *filename) {
@@ -1041,9 +1040,8 @@ void readChange(void) {
 }
 
 void gbaCartDump(void) {
-#ifdef SCREENSWAP
-	lcdMainOnTop();
-#endif
+	if(config->screenSwap())
+		lcdMainOnTop();
 
 	font->clear(false);
 	font->print(firstCol, 0, false, STR_LOADING, alignStart);
@@ -1265,7 +1263,6 @@ void gbaCartDump(void) {
 		}
 	}
 
-#ifdef SCREENSWAP
-	screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-#endif
+	if(config->screenSwap())
+		screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
 }

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -33,6 +33,7 @@
 #include <fat.h>
 
 #include "main.h"
+#include "config.h"
 #include "date.h"
 #include "screenshot.h"
 #include "fileOperations.h"
@@ -170,9 +171,8 @@ void showDirectoryContents(std::vector<DirEntry> &dirContents, int fileOffset, i
 }
 
 FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
-#ifdef SCREENSWAP
-	lcdMainOnTop();
-#endif
+	if(config->screenSwap())
+		lcdMainOnTop();
 
 	int pressed = 0, held = 0;
 	std::vector<FileOperation> operations;
@@ -301,9 +301,9 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 			swiWaitForVBlank();
 
 			if(driveRemoved(currentDrive)) {
-#ifdef SCREENSWAP
-				screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-#endif
+				if(config->screenSwap())
+					screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+
 				return FileOperation::none;
 			}
 		} while (!(pressed & (KEY_UP| KEY_DOWN | KEY_A | KEY_B | KEY_L)));
@@ -468,14 +468,15 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 				}
 			}
 			keysDownRepeat(); // prevent unwanted key repeat
-#ifdef SCREENSWAP
-			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-#endif
+
+			if(config->screenSwap())
+				screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+
 			return operations[optionOffset];
 		} else if (pressed & KEY_B) {
-#ifdef SCREENSWAP
-			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-#endif
+			if(config->screenSwap())
+				screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+
 			return FileOperation::none;
 		}
 		// Make a screenshot
@@ -486,9 +487,8 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 }
 
 bool fileBrowse_paste(char dest[256]) {
-#ifdef SCREENSWAP
-	lcdMainOnTop();
-#endif
+	if(config->screenSwap())
+		lcdMainOnTop();
 
 	int pressed = 0;
 	int optionOffset = 0;
@@ -549,15 +549,16 @@ bool fileBrowse_paste(char dest[256]) {
 			}
 			clipboardUsed = true;		// Disable clipboard restore
 			clipboardOn = false;	// Clear clipboard after copying or moving
-#ifdef SCREENSWAP
-			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-#endif
+
+			if(config->screenSwap())
+				screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+
 			return true;
 		}
 		if (pressed & KEY_B) {
-#ifdef SCREENSWAP
-			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-#endif
+			if(config->screenSwap())
+				screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
+
 			return false;
 		}
 	}
@@ -966,18 +967,10 @@ std::string browseForFile (void) {
 			clipboardOn = !clipboardOn;
 		} if (pressed & KEY_START) { // START menu
 			startMenu();
-		}
-
-#ifdef SCREENSWAP
-		// Swap screens
-		else if (pressed & KEY_TOUCH) {
+		} else if (pressed & config->screenSwapKey()) { // Swap screens
 			screenSwapped = !screenSwapped;
 			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-		}
-#endif
-
-		// Make a screenshot
-		else if ((held & KEY_R) && (pressed & KEY_L)) {
+		} else if ((held & KEY_R) && (pressed & KEY_L)) { // Make a screenshot
 			if(screenshot())
 				getDirectoryContents(dirContents);
 		}

--- a/arm9/source/keyboard.cpp
+++ b/arm9/source/keyboard.cpp
@@ -1,4 +1,5 @@
 #include "keyboard.h"
+#include "config.h"
 #include "font.h"
 #include "language.h"
 #include "main.h"
@@ -7,9 +8,8 @@
 #include <string.h>
 
 std::string kbdGetString(std::string label, int maxSize, std::string oldStr) {
-#ifdef SCREENSWAP
-	lcdMainOnTop();
-#endif
+	if(config->screenSwap())
+		lcdMainOnTop();
 
 	font->clear(false);
 	font->update(false);
@@ -155,9 +155,8 @@ std::string kbdGetString(std::string label, int maxSize, std::string oldStr) {
 	}
 	keyboardHide();
 
-#ifdef SCREENSWAP
-	screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
-#endif
+	if(config->screenSwap())
+		screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
 
 	return output;
 }

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -50,9 +50,7 @@ char titleName[64] = {" "};
 int screenMode = 0;
 
 bool appInited = false;
-#ifdef SCREENSWAP
 bool screenSwapped = false;
-#endif
 
 bool arm7SCFGLocked = false;
 bool isRegularDS = true;
@@ -115,11 +113,7 @@ int main(int argc, char **argv) {
 	
 	bool yHeld = false;
 
-#ifdef SCREENSWAP
-	sprintf(titleName, "GodMode9i (Screen Swap) %s", VER_NUMBER);
-#else
 	sprintf(titleName, "GodMode9i %s", VER_NUMBER);
-#endif
 
 	// initialize video mode
 	videoSetMode(MODE_5_2D);

--- a/arm9/source/main.h
+++ b/arm9/source/main.h
@@ -6,9 +6,7 @@ extern char titleName[32];
 extern int screenMode;
 
 extern bool appInited;
-#ifdef SCREENSWAP
 extern bool screenSwapped;
-#endif
 
 extern bool arm7SCFGLocked;
 extern bool isRegularDS;

--- a/arm9/source/titleManager.cpp
+++ b/arm9/source/titleManager.cpp
@@ -1,4 +1,5 @@
 #include "titleManager.h"
+#include "config.h"
 #include "driveOperations.h"
 #include "file_browse.h"
 #include "fileOperations.h"
@@ -111,11 +112,7 @@ void dumpTitle(TitleInfo &title) {
 			pressed = keysDownRepeat();
 			held = keysHeld();
 			swiWaitForVBlank();
-		} while (!(pressed & (KEY_UP| KEY_DOWN | KEY_A | KEY_B | KEY_L))
-#ifdef SCREENSWAP
-				&& !(pressed & KEY_TOUCH)
-#endif
-				);
+		} while (!(pressed & (KEY_UP| KEY_DOWN | KEY_A | KEY_B | KEY_L | config->screenSwapKey())));
 
 		if (pressed & KEY_UP)
 			optionOffset--;
@@ -186,13 +183,11 @@ void dumpTitle(TitleInfo &title) {
 		if (pressed & KEY_B)
 			return;
 
-#ifdef SCREENSWAP
 		// Swap screens
-		if (pressed & KEY_TOUCH) {
+		if (pressed & config->screenSwapKey()) {
 			screenSwapped = !screenSwapped;
 			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
 		}
-#endif
 
 		// Make a screenshot
 		if ((held & KEY_R) && (pressed & KEY_L)) {
@@ -301,11 +296,7 @@ void titleManager() {
 			scanKeys();
 			pressed = keysDown();
 			held = keysDownRepeat();
-		} while(!(held & (KEY_UP | KEY_DOWN | KEY_LEFT | KEY_RIGHT | KEY_A | KEY_B | KEY_L
-#ifdef SCREENSWAP
-				| KEY_TOUCH
-#endif
-				)));
+		} while(!(held & (KEY_UP | KEY_DOWN | KEY_LEFT | KEY_RIGHT | KEY_A | KEY_B | KEY_L | config->screenSwapKey())));
 
 		if(held & KEY_UP) {
 			cursorPosition--;
@@ -335,13 +326,11 @@ void titleManager() {
 		if (cursorPosition > scrollOffset + ENTRIES_PER_SCREEN - 1)
 			scrollOffset = cursorPosition - ENTRIES_PER_SCREEN + 1;
 
-#ifdef SCREENSWAP
 		// Swap screens
-		if (pressed & KEY_TOUCH) {
+		if (pressed & config->screenSwapKey()) {
 			screenSwapped = !screenSwapped;
 			screenSwapped ? lcdMainOnBottom() : lcdMainOnTop();
 		}
-#endif
 
 		if((pressed & KEY_L) && (keysHeld() & KEY_R)) {
 			screenshot();


### PR DESCRIPTION
- Changes the screen swap option from a compile time `#define` to an option in the `config.ini`
- This makes it much easier to use since we aren't making screen swap builds so currently the only way to use it is to build it yourself
- Closes #168 (?)