### PR TITLE
Upload unzipped builds alongside the 7z

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -44,6 +44,9 @@ jobs:
           7z a GodMode9i.7z GodMode9i/
 
           mkdir -p ~/artifacts
+          cp GodMode9i.dsi ~/artifacts
+          cp GodMode9i.nds ~/artifacts
+          cp GodMode9i.cia ~/artifacts
           cp GodMode9i.7z ~/artifacts
 
           echo ::set-output name=commit_tag::$(git describe --abbrev=0 --tags)


### PR DESCRIPTION
Makes Actions upload the unzipped builds alongside the 7z, for compatibility with dsidl and Universal-Updater DSi in the future