### PR TITLE
Dump GBA RTC data in metadata and saves

### DIFF
--- a/arm9/source/date.cpp
+++ b/arm9/source/date.cpp
@@ -7,23 +7,21 @@
 #include <time.h>
 
 /**
- * Get the current time formatted for the top bar.
- * @return std::string containing the time.
- */
-std::string RetTime()
-{
-	return RetTime(STR_TIME_FORMAT.c_str());
-}
-
-/**
  * Get the current time formatted as specified.
  * @return std::string containing the time.
  */
-std::string RetTime(const char *format)
+std::string RetTime(const char *format, time_t *raw)
 {
-	time_t raw;
-	time(&raw);
-	const struct tm *Time = localtime(&raw);
+	if (!format) 
+	{
+		format = STR_TIME_FORMAT.c_str();
+	}
+	time_t systime;
+	if (!raw) {
+		raw = &systime;
+		time(raw);
+	}
+	const struct tm *Time = localtime(raw);
 
 	char tmp[64];
 	strftime(tmp, sizeof(tmp), format, Time);

--- a/arm9/source/date.h
+++ b/arm9/source/date.h
@@ -4,15 +4,11 @@
 #include <string>
 
 /**
- * Get the current time formatted for the top bar.
+ * Format the time as specified.
+ * If no format is specified, use format for the top bar.
+ * If no time is specified, use the system time.
  * @return std::string containing the time.
  */
-std::string RetTime();
-
-/**
- * Get the current time formatted as specified.
- * @return std::string containing the time.
- */
-std::string RetTime(const char *format);
+std::string RetTime(const char *format = nullptr, time_t *raw = nullptr);
 
 #endif // DATE_H

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -1004,7 +1004,7 @@ void gbaCartSaveRestore(const char *filename) {
 		fseek(sourceFile, 0, SEEK_END);
 		size_t length = ftell(sourceFile);
 		fseek(sourceFile, 0, SEEK_SET);
-		if(length != size) {
+		if(length != size && length != size + 16) {
 			fclose(sourceFile);
 
 			dumpFailMsg(STR_SAVE_SIZE_MISMATCH_CART);

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -1255,15 +1255,17 @@ void gbaCartDump(void) {
 				fprintf(destinationFile, "Save chip ID : 0x%04X\n", gbaGetFlashId());
 
 			u8 cartRtc[RTC_SIZE];
-			gbaGetRtc(cartRtc);
-			struct tm cartTm = gbaRtcToTm(cartRtc);
-			time_t cartTime = mktime(&cartTm);
+			if (gbaGetRtc(cartRtc)) {
+				struct tm cartTm = gbaRtcToTm(cartRtc);
+				time_t cartTime = mktime(&cartTm);
+				fprintf(destinationFile,
+					"Cart time    : %s\n",
+					RetTime("%Y-%m-%d %H:%M:%S", &cartTime).c_str());
+			}
 
 			fprintf(destinationFile,
-				"Cart time    : %s\n"
 				"Timestamp    : %s\n"
 				"GM9i Version : " VER_NUMBER "\n",
-				RetTime("%Y-%m-%d %H:%M:%S", &cartTime).c_str(),
 				RetTime("%Y-%m-%d %H:%M:%S").c_str());
 
 			fclose(destinationFile);

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -1254,14 +1254,16 @@ void gbaCartDump(void) {
 			if(saveType == SAVE_GBA_FLASH_64 || saveType == SAVE_GBA_FLASH_128)
 				fprintf(destinationFile, "Save chip ID : 0x%04X\n", gbaGetFlashId());
 
-			u8 cartTime[RTC_SIZE];
-			gbaGetRtc(cartTime);
+			u8 cartRtc[RTC_SIZE];
+			gbaGetRtc(cartRtc);
+			struct tm cartTm = gbaRtcToTm(cartRtc);
+			time_t cartTime = mktime(&cartTm);
 
 			fprintf(destinationFile,
-				"Cart time    : %x-%x-%x\n"
+				"Cart time    : %s\n"
 				"Timestamp    : %s\n"
 				"GM9i Version : " VER_NUMBER "\n",
-				cartTime[RTC_YEAR], cartTime[RTC_MONTH], cartTime[RTC_DAY],
+				RetTime("%Y-%m-%d %H:%M:%S", &cartTime).c_str(),
 				RetTime("%Y-%m-%d %H:%M:%S").c_str());
 
 			fclose(destinationFile);

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -1254,11 +1254,14 @@ void gbaCartDump(void) {
 			if(saveType == SAVE_GBA_FLASH_64 || saveType == SAVE_GBA_FLASH_128)
 				fprintf(destinationFile, "Save chip ID : 0x%04X\n", gbaGetFlashId());
 
+			u8 cartTime[RTC_SIZE];
+			gbaGetRtc(cartTime);
+
 			fprintf(destinationFile,
-				"RTC Present  : %s\n"
+				"Cart time    : %x-%x-%x\n"
 				"Timestamp    : %s\n"
 				"GM9i Version : " VER_NUMBER "\n",
-				gbaIsRtc() ? "Yes" : "No",
+				cartTime[RTC_YEAR], cartTime[RTC_MONTH], cartTime[RTC_DAY],
 				RetTime("%Y-%m-%d %H:%M:%S").c_str());
 
 			fclose(destinationFile);

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -1255,8 +1255,10 @@ void gbaCartDump(void) {
 				fprintf(destinationFile, "Save chip ID : 0x%04X\n", gbaGetFlashId());
 
 			fprintf(destinationFile,
+				"RTC Present  : %s\n"
 				"Timestamp    : %s\n"
 				"GM9i Version : " VER_NUMBER "\n",
+				gbaIsRtc() ? "Yes" : "No",
 				RetTime("%Y-%m-%d %H:%M:%S").c_str());
 
 			fclose(destinationFile);

--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -964,6 +964,14 @@ void gbaCartSaveDump(const char *filename) {
 
 	FILE *destinationFile = fopen(filename, "wb");
 	fwrite(buffer, 1, size, destinationFile);
+	
+	u8 cartRtc[RTC_SIZE];
+	if (gbaGetRtc(cartRtc)) {
+		fwrite(cartRtc, 1, RTC_SIZE, destinationFile);
+		u64 systime = time(nullptr);
+		fwrite(&systime, 1, 8, destinationFile);
+	}
+
 	fclose(destinationFile);
 	delete[] buffer;
 }

--- a/arm9/source/file_browse.cpp
+++ b/arm9/source/file_browse.cpp
@@ -196,7 +196,8 @@ FileOperation fileBrowse_A(DirEntry* entry, char path[PATH_MAX]) {
 		if(extension(entry->name, {"sav", "sav1", "sav2", "sav3", "sav4", "sav5", "sav6", "sav7", "sav8", "sav9"})) {
 			if(!(io_dldi_data->ioInterface.features & FEATURE_SLOT_NDS) || entry->size <= (1 << 20))
 				operations.push_back(FileOperation::restoreSaveNds);
-			if(isRegularDS && (entry->size == 512 || entry->size == 8192 || entry->size == 32768 || entry->size == 65536 || entry->size == 131072))
+			if(isRegularDS && (entry->size == 512 || entry->size == 8192 || entry->size == 32768 || entry->size == 65536 || entry->size == 131072 
+				|| entry->size == 528 || entry->size == 8208 || entry->size == 32784 || entry->size == 65552 || entry->size == 131088))
 				operations.push_back(FileOperation::restoreSaveGba);
 		}
 		if(currentDrive != Drive::fatImg && extension(entry->name, {"img", "sd", "sav", "pub", "pu1", "pu2", "pu3", "pu4", "pu5", "pu6", "pu7", "pu8", "pu9", "prv", "pr1", "pr2", "pr3", "pr4", "pr5", "pr6", "pr7", "pr8", "pr9", "0000"})) {

--- a/arm9/source/gba.cpp
+++ b/arm9/source/gba.cpp
@@ -461,3 +461,20 @@ bool gbaGetRtc(u8 *rtc)
 	
 	rtcDisable();
 }
+
+static uint8_t unBCD(uint8_t byte) {
+	return (byte >> 4) * 10 + (byte & 0xF);
+}
+
+struct tm gbaRtcToTm(const u8 *rtc)
+{
+	struct tm res;
+	res.tm_year = unBCD(rtc[RTC_YEAR]) + 100;
+	res.tm_mon = unBCD(rtc[RTC_MONTH]) - 1;
+	res.tm_mday = unBCD(rtc[RTC_DAY]);
+	res.tm_hour = unBCD(rtc[RTC_HOUR]);
+	res.tm_min = unBCD(rtc[RTC_MINUTE]);
+	res.tm_sec = unBCD(rtc[RTC_SECOND]);
+	res.tm_isdst = -1;
+	return res;
+}

--- a/arm9/source/gba.cpp
+++ b/arm9/source/gba.cpp
@@ -457,9 +457,12 @@ bool gbaGetRtc(u8 *rtc)
 	GPIO_DIR = 5;
 	for(i=4; i<7; i++)
 		rtc[i] = rtcReadData();
-	return 0;
 	
 	rtcDisable();
+	
+	// Month must be 1 to 12 in BCD for valid RTC
+	// If month is 0, invalid RTC
+	return rtc[RTC_MONTH] >= 0x01 && rtc[RTC_MONTH] <= 0x12;
 }
 
 static uint8_t unBCD(uint8_t byte) {

--- a/arm9/source/gba.cpp
+++ b/arm9/source/gba.cpp
@@ -168,6 +168,12 @@ uint32 gbaGetSaveSize(saveTypeGBA type)
 		return 1 << gbaGetSaveSizeLog2(type);
 }
 
+bool gbaIsRtc()
+{
+	// heuristic
+	return !*(vu16*) 0x080000c4;
+}
+
 bool gbaReadSave(u8 *dst, u32 src, u32 len, saveTypeGBA type)
 {
 	int nbanks = 2; // for type 4,5

--- a/arm9/source/gba.cpp
+++ b/arm9/source/gba.cpp
@@ -458,6 +458,14 @@ bool gbaGetRtc(u8 *rtc)
 	for(i=4; i<7; i++)
 		rtc[i] = rtcReadData();
 	
+	GPIO_DAT = 1;
+	GPIO_DIR = 7;
+	GPIO_DAT = 1;
+	GPIO_DAT = 5;
+	rtcWriteCmd(RTC_CMD_READ(4));
+	GPIO_DIR = 5;
+	rtc[7] = rtcReadData();
+	
 	rtcDisable();
 	
 	// Month must be 1 to 12 in BCD for valid RTC

--- a/arm9/source/gba.h
+++ b/arm9/source/gba.h
@@ -42,6 +42,8 @@ uint32 gbaGetSaveSize(saveTypeGBA type = SAVE_GBA_NONE);
 uint32 gbaGetSaveSizeLog2(saveTypeGBA type = SAVE_GBA_NONE);
 u16 gbaGetFlashId();
 
+bool gbaIsRtc();
+
 bool gbaReadSave(u8 *dst, u32 src, u32 len, saveTypeGBA type);
 bool gbaWriteSave(u32 dst, u8 *src, u32 len, saveTypeGBA type);
 bool gbaFormatSave(saveTypeGBA type);

--- a/arm9/source/gba.h
+++ b/arm9/source/gba.h
@@ -34,6 +34,17 @@ enum saveTypeGBA {
 	SAVE_GBA_FLASH_128 // 128k
 };
 
+enum GbaRtc {
+	RTC_YEAR,
+	RTC_MONTH,
+	RTC_DAY,
+	RTC_WEEKDAY,
+	RTC_HOUR,
+	RTC_MINUTE,
+	RTC_SECOND,
+	RTC_CONTROL,
+	RTC_SIZE
+};
 
 // --------------------
 bool gbaIsGame();
@@ -42,11 +53,10 @@ uint32 gbaGetSaveSize(saveTypeGBA type = SAVE_GBA_NONE);
 uint32 gbaGetSaveSizeLog2(saveTypeGBA type = SAVE_GBA_NONE);
 u16 gbaGetFlashId();
 
-bool gbaIsRtc();
-
 bool gbaReadSave(u8 *dst, u32 src, u32 len, saveTypeGBA type);
 bool gbaWriteSave(u32 dst, u8 *src, u32 len, saveTypeGBA type);
 bool gbaFormatSave(saveTypeGBA type);
 
+bool gbaGetRtc(u8 *rtc);
 
 #endif // __GBA_H__

--- a/arm9/source/gba.h
+++ b/arm9/source/gba.h
@@ -58,5 +58,6 @@ bool gbaWriteSave(u32 dst, u8 *src, u32 len, saveTypeGBA type);
 bool gbaFormatSave(saveTypeGBA type);
 
 bool gbaGetRtc(u8 *rtc);
+struct tm gbaRtcToTm(const u8 *rtc);
 
 #endif // __GBA_H__


### PR DESCRIPTION
For GBA carts which have RTC, add the ability to dump the current time. The cart timestamp is added as another metadata field. The cart RTC data and the system timestamp is also appended to saves in the same format used by mGBA and FlashGBX. Restoring saves with appended RTC data is also permitted, but the RTC data is ignored.
Carts without RTC are unaffected.
Ability to restore RTC data not yet supported.