### PR TITLE
Only dump the RSA key on trimmed ROMs when it exists

### DIFF
--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -895,17 +895,9 @@ void ndsCardDump(void) {
 
 				if (currentSize < 0x8000) {
 					if (romSize == ndsCardHeader.romSize + 0x88) {
-						// Trimming with RSA, check if it's real
-						u8 *ptr = copyBuf + (ndsCardHeader.romSize % 0x8000);
-						bool hasRsa = false;
-						for (int i = 0; i < 0x88; i++) {
-							if (ptr[i] != 0xFF) {
-								hasRsa = true;
-								break;
-							}
-						}
-
-						if (!hasRsa) {
+						// Trimming, check for RSA key
+						// 'ac', auth code -- magic number
+						if (*(u16 *)(copyBuf + (ndsCardHeader.romSize % 0x8000)) != 0x6361) {
 							romSize -= 0x88;
 							currentSize -= 0x88;
 						}

--- a/arm9/source/fileOperations.cpp
+++ b/arm9/source/fileOperations.cpp
@@ -136,11 +136,26 @@ int trimNds(const char *fileName) {
 
 		fseek(file, 0, SEEK_END);
 		u32 fileSize = ftell(file);
+		fseek(file, 0, SEEK_SET);
+
+		u32 romSize;
+		if((ndsCardHeader.unitCode != 0) && (ndsCardHeader.twlRomSize > 0)) {
+			romSize = ndsCardHeader.twlRomSize;
+		} else {
+			romSize = ndsCardHeader.romSize;
+
+			// Check if it has an RSA key or not
+			fseek(file, romSize, SEEK_SET);
+			u16 magic;
+			if(fread(&magic, sizeof(u16), 1, file) == 1) {
+				// 'ac', auth code -- magic number
+				if(magic == 0x6361)
+					romSize += 0x88;
+			}
+
+		}
 
 		fclose(file);
-
-		u32 romSize = ((ndsCardHeader.unitCode != 0) && (ndsCardHeader.twlRomSize > 0))
-						? ndsCardHeader.twlRomSize : ndsCardHeader.romSize + 0x88;
 
 		if(fileSize == romSize) {
 			font->clear(false);


### PR DESCRIPTION
Tested using Mario Kart DS, LEGO Indiana Jones, and Metroid Prime Pinball

Closes https://github.com/DS-Homebrew/GodMode9i/issues/214