### PR TITLE
Add support for NAND save "DS Guide" cart

### DIFF
--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -296,6 +296,8 @@ u32 cardNandGetSaveSize(void) {
 			return 16 << 20; // 16MByte - WarioWare D.I.Y.
 		case 0x004B5355: // 'USK'
 			return 64 << 20; // 64MByte - Face Training
+		case 0x00444755: // 'UGD'
+			return 128 << 20; // 128MByte - DS Guide
 	}
 
 	return 0;


### PR DESCRIPTION
128MB NAND carts that were recently found in a DS kiosk setup. TID is "UGDA"

Relevant DAT:
https://datomatic.no-intro.org/index.php?page=show_record&s=28&n=z571