### PR TITLE
Replace any non alphanumerical character with '_' for output filenames

### DIFF
--- a/arm9/source/dumpOperations.cpp
+++ b/arm9/source/dumpOperations.cpp
@@ -16,6 +16,7 @@
 #include "screenshot.h"
 #include "version.h"
 
+#include <cctype>
 #include <dirent.h>
 #include <nds.h>
 #include <nds/arm9/dldi.h>
@@ -825,18 +826,8 @@ void ndsCardDump(void) {
 		sprintf(gameTitle, "NO-TITLE");
 	} else {
 		for(uint i = 0; i < sizeof(gameTitle); i++) {
-			switch(gameTitle[i]) {
-				case '>':
-				case '<':
-				case ':':
-				case '"':
-				case '/':
-				case '\x5C':
-				case '|':
-				case '?':
-				case '*':
-					gameTitle[i] = '_';
-			}
+			if(!isalnum(gameTitle[i]))
+				gameTitle[i] = '_';
 		}
 	}
 	if (gameCode[0] == 0 || gameCode[0] == 0x23 || gameCode[0] == 0xFF) {


### PR DESCRIPTION
Fixes dumping carts with headers that have random garbage data in their gameTitle that are not actually ascii characters, thus making the dump fail because the output file cannot be opened