### PR TITLE
Show console and mode on the boot splash

### DIFF
--- a/arm7/source/main.c
+++ b/arm7/source/main.c
@@ -190,7 +190,8 @@ int main() {
 	}
 
 	fifoSendValue32(FIFO_USER_03, REG_SCFG_EXT);
-	fifoSendValue32(FIFO_USER_07, *(u16*)(0x4004700));
+	// Low 16 bits are SNDEXCNT; high 8 bits carry power-management reg 4 (for DS Lite detection).
+	fifoSendValue32(FIFO_USER_07, ((u32)readPowerManagement(4) << 16) | (*(u16*)(0x4004700) & 0xFFFF));
 	fifoSendValue32(FIFO_USER_06, 1);
 
 	// Keep the ARM7 mostly idle

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -35,6 +35,7 @@ bool screenSwapped = false;
 
 bool arm7SCFGLocked = false;
 bool isRegularDS = true;
+bool isDSLite = false;
 // bool bios9iEnabled = false;
 bool is3DS = false;
 int ownNitroFSMounted;
@@ -88,6 +89,8 @@ static std::string getConsoleModeStr(void) {
 		model = "Nintendo 3DS";
 	else if (!isRegularDS)
 		model = "Nintendo DSi";
+	else if (isDSLite)
+		model = "Nintendo DS Lite";
 	else
 		model = "Nintendo DS";
 	return model + (isDSiMode() ? " (DSi mode)" : " (DS mode)");
@@ -162,9 +165,16 @@ int main(int argc, char **argv) {
 
 	fifoWaitValue32(FIFO_USER_06);
 	if (fifoGetValue32(FIFO_USER_03) == 0) arm7SCFGLocked = true;
-	u16 arm7_SNDEXCNT = fifoGetValue32(FIFO_USER_07);
+	u32 arm7_fifo7 = fifoGetValue32(FIFO_USER_07);
+	u16 arm7_SNDEXCNT = arm7_fifo7 & 0xFFFF;
 	if (arm7_SNDEXCNT != 0) isRegularDS = false;	// If sound frequency setting is found, then the console is not a DS Phat/Lite
 	fifoSendValue32(FIFO_USER_07, 0);
+
+	// The arm7 packs power-management register 4 into the high bits of that value.
+	// A DS Lite's reg 4 (backlight) has bits 4-7 fixed to 4; on the original DS it
+	// just mirrors register 0, so this distinguishes a DS Lite from a DS Phat.
+	u8 arm7_pmBacklight = (arm7_fifo7 >> 16) & 0xFF;
+	if (isRegularDS && ((arm7_pmBacklight >> 4) & 0xF) == 4) isDSLite = true;
 
 	// Detect RAM size and console model up front (3DS has 32MB of RAM).
 	// arm7 sends FIFO_USER_05 before the sync above, so this is ready here.

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -79,6 +79,21 @@ void vblankHandler (void) {
 }
 
 //---------------------------------------------------------------------------------
+// Describe the detected console model and the mode GodMode9i is running in.
+// Requires isRegularDS/is3DS to be detected first (see the FIFO sync in main()).
+static std::string getConsoleModeStr(void) {
+//---------------------------------------------------------------------------------
+	std::string model;
+	if (is3DS)
+		model = "Nintendo 3DS";
+	else if (!isRegularDS)
+		model = "Nintendo DSi";
+	else
+		model = "Nintendo DS";
+	return model + (isDSiMode() ? " (DSi mode)" : " (DS mode)");
+}
+
+//---------------------------------------------------------------------------------
 int main(int argc, char **argv) {
 //---------------------------------------------------------------------------------
 
@@ -151,6 +166,19 @@ int main(int argc, char **argv) {
 	if (arm7_SNDEXCNT != 0) isRegularDS = false;	// If sound frequency setting is found, then the console is not a DS Phat/Lite
 	fifoSendValue32(FIFO_USER_07, 0);
 
+	// Detect RAM size and console model up front (3DS has 32MB of RAM).
+	// arm7 sends FIFO_USER_05 before the sync above, so this is ready here.
+	bool ram32MB = false;
+	if (isDSiMode() || REG_SCFG_EXT != 0) {
+		*(vu32*)(0x0DFFFE0C) = 0x474D3969;		// Check for 32MB of RAM
+		ram32MB = *(vu32*)(0x0DFFFE0C) == 0x474D3969;
+		if (ram32MB) {
+			is3DS = fifoGetValue32(FIFO_USER_05) != 0xD2;
+		}
+	}
+
+	font->print(1, 6, false, "Running on:  " + getConsoleModeStr());
+
 	if (isDSiMode()) {
 		// bios9iEnabled = true;
 		if (!arm7SCFGLocked) {
@@ -174,6 +202,7 @@ int main(int argc, char **argv) {
 	font->print(1, 2, false, "----------------------------------------");
 	font->print(1, 3, false, "https://github.com/DS-Homebrew/GodMode9i");
 	font->print(1, 5, false, "Booted from: " + bootSource);
+	font->print(1, 6, false, "Running on:  " + getConsoleModeStr());
 	font->print(-2, -2, false, "Mounting drive(s)...", Alignment::right);
 	font->update(false);
 
@@ -189,12 +218,7 @@ int main(int argc, char **argv) {
 	if (isDSiMode()) {
 		scanKeys();
 		yHeld = (keysHeld() & KEY_Y);
-		*(vu32*)(0x0DFFFE0C) = 0x474D3969;		// Check for 32MB of RAM
-		const bool ram32MB = *(vu32*)(0x0DFFFE0C) == 0x474D3969;
 		ramdriveMount(ram32MB);
-		if (ram32MB) {
-			is3DS = fifoGetValue32(FIFO_USER_05) != 0xD2;
-		}
 		//if (!(keysHeld() & KEY_X)) {
 			nandMounted = nandMount();
 		//}
@@ -206,12 +230,7 @@ int main(int argc, char **argv) {
 		fwrite((void*)0x2FFFD00, 1, 8, cidFile);
 		fclose(cidFile);*/
 	} else if (REG_SCFG_EXT != 0) {
-		*(vu32*)(0x0DFFFE0C) = 0x474D3969;		// Check for 32MB of RAM
-		const bool ram32MB = *(vu32*)(0x0DFFFE0C) == 0x474D3969;
 		ramdriveMount(ram32MB);
-		if (ram32MB) {
-			is3DS = fifoGetValue32(FIFO_USER_05) != 0xD2;
-		}
 
 		/* FILE* bios = fopen("sd:/_nds/bios9i.bin", "rb");
 		if (!bios) {


### PR DESCRIPTION
## Summary

The boot splash now shows which console you're on and which mode
GodMode9i booted in, right under the "Booted from:" line:

    Booted from: SD Card (sd:/)
    Running on:  Nintendo 3DS (DSi mode)

Small quality-of-life touch: since DS vs DSi mode changes what
GodMode9i can actually reach, you can now confirm the hardware and
the mode at a glance instead of guessing.