### PR TITLE
Detect DS Lite from the firmware console type

### DIFF
--- a/arm7/source/main.c
+++ b/arm7/source/main.c
@@ -190,8 +190,10 @@ int main() {
 	}
 
 	fifoSendValue32(FIFO_USER_03, REG_SCFG_EXT);
-	// Low 16 bits are SNDEXCNT; high 8 bits carry power-management reg 4 (for DS Lite detection).
-	fifoSendValue32(FIFO_USER_07, ((u32)readPowerManagement(4) << 16) | (*(u16*)(0x4004700) & 0xFFFF));
+	// Low 16 bits are SNDEXCNT; high 8 bits carry the firmware "console type" byte (for DS Lite detection).
+	u8 consoleType = 0xFF;			// FFh/00h = original DS; left untouched if readFirmware fails
+	readFirmware(0x1D, &consoleType, 1);
+	fifoSendValue32(FIFO_USER_07, ((u32)consoleType << 16) | (*(u16*)(0x4004700) & 0xFFFF));
 	fifoSendValue32(FIFO_USER_06, 1);
 
 	// Keep the ARM7 mostly idle

--- a/arm7/source/main.c
+++ b/arm7/source/main.c
@@ -190,10 +190,12 @@ int main() {
 	}
 
 	fifoSendValue32(FIFO_USER_03, REG_SCFG_EXT);
-	// Low 16 bits are SNDEXCNT; high 8 bits carry the firmware "console type" byte (for DS Lite detection).
+	// Two DS Lite signals for the arm9 to cross-check: bits 16-23 = power-management
+	// register 4 (backlight), bits 24-31 = firmware "console type" byte (offset 0x1D).
+	// Low 16 bits stay SNDEXCNT.
 	u8 consoleType = 0xFF;			// FFh/00h = original DS; left untouched if readFirmware fails
 	readFirmware(0x1D, &consoleType, 1);
-	fifoSendValue32(FIFO_USER_07, ((u32)consoleType << 16) | (*(u16*)(0x4004700) & 0xFFFF));
+	fifoSendValue32(FIFO_USER_07, ((u32)consoleType << 24) | ((u32)readPowerManagement(4) << 16) | (*(u16*)(0x4004700) & 0xFFFF));
 	fifoSendValue32(FIFO_USER_06, 1);
 
 	// Keep the ARM7 mostly idle

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -170,13 +170,19 @@ int main(int argc, char **argv) {
 	if (arm7_SNDEXCNT != 0) isRegularDS = false;	// If sound frequency setting is found, then the console is not a DS Phat/Lite
 	fifoSendValue32(FIFO_USER_07, 0);
 
-	// The arm7 packs the firmware "console type" byte (offset 0x1D) into the high bits.
-	// 20h = DS Lite, 63h = iQue DS Lite; FFh/00h = original DS. This is Nintendo's own
-	// stamp, so unlike the backlight register it doesn't trip on late "CPU-20" DS Phats
-	// that borrow the DS Lite's power chip. Match exact values: old phats store FFh,
-	// which has bit 5 set, so a "bit 5 = Lite" test would flag every phat.
-	u8 arm7_consoleType = (arm7_fifo7 >> 16) & 0xFF;
-	if (isRegularDS && (arm7_consoleType == 0x20 || arm7_consoleType == 0x63)) isDSLite = true;
+	// Two DS Lite signals from the arm7, cross-checked so neither's blind spot leaks through:
+	//  - power-management register 4 (backlight): a Lite fixes bits 4-7 to 4, but so does the
+	//    late "CPU-20" DS Phat that borrows the Lite's power chip, so this alone over-reports.
+	//  - firmware "console type" byte (offset 0x1D): 20h/35h/63h = Lite family, FFh = Phat. This
+	//    is Nintendo's factory stamp, but it lives in flashable firmware, so it alone can be spoofed.
+	// A factory CPU-20 Phat ships Phat firmware (FFh), so requiring both to agree keeps it labelled
+	// a Phat while still catching real Lites. The only case this can't tell apart is a Lite running
+	// cross-flashed Phat firmware (reads as Phat), which is rare and cosmetic.
+	u8 arm7_pmBacklight = (arm7_fifo7 >> 16) & 0xFF;
+	u8 arm7_consoleType = (arm7_fifo7 >> 24) & 0xFF;
+	bool pmSaysLite = ((arm7_pmBacklight >> 4) & 0xF) == 4;
+	bool fwSaysLite = (arm7_consoleType == 0x20 || arm7_consoleType == 0x35 || arm7_consoleType == 0x63);
+	if (isRegularDS && pmSaysLite && fwSaysLite) isDSLite = true;
 
 	// Detect RAM size and console model up front (3DS has 32MB of RAM).
 	// arm7 sends FIFO_USER_05 before the sync above, so this is ready here.

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -93,7 +93,7 @@ static std::string getConsoleModeStr(void) {
 		model = "Nintendo DS Lite";
 	else
 		model = "Nintendo DS";
-	return model + (isDSiMode() ? " (DSi mode)" : " (DS mode)");
+	return model + (isDSiMode() ? " (DSi Mode)" : " (DS Mode)");
 }
 
 //---------------------------------------------------------------------------------
@@ -170,11 +170,13 @@ int main(int argc, char **argv) {
 	if (arm7_SNDEXCNT != 0) isRegularDS = false;	// If sound frequency setting is found, then the console is not a DS Phat/Lite
 	fifoSendValue32(FIFO_USER_07, 0);
 
-	// The arm7 packs power-management register 4 into the high bits of that value.
-	// A DS Lite's reg 4 (backlight) has bits 4-7 fixed to 4; on the original DS it
-	// just mirrors register 0, so this distinguishes a DS Lite from a DS Phat.
-	u8 arm7_pmBacklight = (arm7_fifo7 >> 16) & 0xFF;
-	if (isRegularDS && ((arm7_pmBacklight >> 4) & 0xF) == 4) isDSLite = true;
+	// The arm7 packs the firmware "console type" byte (offset 0x1D) into the high bits.
+	// 20h = DS Lite, 63h = iQue DS Lite; FFh/00h = original DS. This is Nintendo's own
+	// stamp, so unlike the backlight register it doesn't trip on late "CPU-20" DS Phats
+	// that borrow the DS Lite's power chip. Match exact values: old phats store FFh,
+	// which has bit 5 set, so a "bit 5 = Lite" test would flag every phat.
+	u8 arm7_consoleType = (arm7_fifo7 >> 16) & 0xFF;
+	if (isRegularDS && (arm7_consoleType == 0x20 || arm7_consoleType == 0x63)) isDSLite = true;
 
 	// Detect RAM size and console model up front (3DS has 32MB of RAM).
 	// arm7 sends FIFO_USER_05 before the sync above, so this is ready here.


### PR DESCRIPTION
Follow-up to #265. Swaps the DS Lite detection from the power-management backlight register to the firmware console-type byte at `0x1D`.

Wokann pointed out the backlight register isn't Lite-exclusive: late "CPU-20" DS Phat boards borrow the DS Lite power chip and expose it too, so they'd be misdetected as a Lite. The firmware console-type stamp is independent of that chip (`20h` = DS Lite, `63h` = iQue DS Lite, `FFh`/`00h` = DS), so it avoids the false positive. Same byte [DSiFetch ](https://git.sr.ht/~dlm/dsifetch)reads for this.

Also matches the "Mode" casing to the "Booted from:" line.
