### PR TITLE
Detect DS Lite from the WiFi chip ID

### DIFF
--- a/arm7/source/main.c
+++ b/arm7/source/main.c
@@ -190,12 +190,16 @@ int main() {
 	}
 
 	fifoSendValue32(FIFO_USER_03, REG_SCFG_EXT);
-	// Two DS Lite signals for the arm9 to cross-check: bits 16-23 = power-management
-	// register 4 (backlight), bits 24-31 = firmware "console type" byte (offset 0x1D).
-	// Low 16 bits stay SNDEXCNT.
-	u8 consoleType = 0xFF;			// FFh/00h = original DS; left untouched if readFirmware fails
-	readFirmware(0x1D, &consoleType, 1);
-	fifoSendValue32(FIFO_USER_07, ((u32)consoleType << 24) | ((u32)readPowerManagement(4) << 16) | (*(u16*)(0x4004700) & 0xFFFF));
+	fifoSendValue32(FIFO_USER_07, *(u16*)(0x4004700) & 0xFFFF);	// SNDEXCNT (low 16 bits)
+
+	// DS Lite detection: the WiFi controller chip ID (W_ID, 4808000h) is 1440h on the original
+	// DS and C340h on the DS Lite. It lives in WiFi silicon, so unlike the firmware console-type
+	// byte (offset 1Dh) it can't be reflashed or spoofed. POWCNT2 (4000304h) bit1 gates the WiFi
+	// port region 4800000h-480FFFFh, so enable it before reading the ID.
+	*(volatile u16*)0x04000304 |= (1 << 1);
+	for (volatile int i = 0; i < 0x4000; i++) { /* let the WiFi region settle */ }
+	fifoSendValue32(FIFO_USER_08, *(volatile u16*)0x04808000);
+
 	fifoSendValue32(FIFO_USER_06, 1);
 
 	// Keep the ARM7 mostly idle

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -172,8 +172,10 @@ int main(int argc, char **argv) {
 
 	// DS Lite detection via the arm7's WiFi controller chip ID (W_ID): on a regular DS it reads
 	// 1440h on the original DS and C340h on the DS Lite. That ID lives in WiFi silicon, not in a
-	// reflashable firmware byte, so it can't be spoofed by cross-flashing. (A DSi/3DS also reports
-	// C340h, but those are already excluded by isRegularDS above.)
+	// reflashable firmware byte, so it can't be spoofed by cross-flashing. It also reads the WiFi
+	// chip rather than the power-management chip, so the late "CPU-20" DS Phat (standard-Phat WiFi
+	// but a DS-Lite PMIC) still reads 1440h and is correctly seen as a Phat, where power-chip checks
+	// mislabel it. (A DSi/3DS also reports C340h, but those are already excluded by isRegularDS above.)
 	if (isRegularDS && arm7_wifiChipId == 0xC340) isDSLite = true;
 
 	// Detect RAM size and console model up front (3DS has 32MB of RAM).

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -165,24 +165,16 @@ int main(int argc, char **argv) {
 
 	fifoWaitValue32(FIFO_USER_06);
 	if (fifoGetValue32(FIFO_USER_03) == 0) arm7SCFGLocked = true;
-	u32 arm7_fifo7 = fifoGetValue32(FIFO_USER_07);
-	u16 arm7_SNDEXCNT = arm7_fifo7 & 0xFFFF;
+	u16 arm7_SNDEXCNT = fifoGetValue32(FIFO_USER_07) & 0xFFFF;
+	u16 arm7_wifiChipId = fifoGetValue32(FIFO_USER_08) & 0xFFFF;	// WiFi chip ID (W_ID): 1440h=DS, C340h=DS Lite
 	if (arm7_SNDEXCNT != 0) isRegularDS = false;	// If sound frequency setting is found, then the console is not a DS Phat/Lite
 	fifoSendValue32(FIFO_USER_07, 0);
 
-	// Two DS Lite signals from the arm7, cross-checked so neither's blind spot leaks through:
-	//  - power-management register 4 (backlight): a Lite fixes bits 4-7 to 4, but so does the
-	//    late "CPU-20" DS Phat that borrows the Lite's power chip, so this alone over-reports.
-	//  - firmware "console type" byte (offset 0x1D): 20h/35h/63h = Lite family, FFh = Phat. This
-	//    is Nintendo's factory stamp, but it lives in flashable firmware, so it alone can be spoofed.
-	// A factory CPU-20 Phat ships Phat firmware (FFh), so requiring both to agree keeps it labelled
-	// a Phat while still catching real Lites. The only case this can't tell apart is a Lite running
-	// cross-flashed Phat firmware (reads as Phat), which is rare and cosmetic.
-	u8 arm7_pmBacklight = (arm7_fifo7 >> 16) & 0xFF;
-	u8 arm7_consoleType = (arm7_fifo7 >> 24) & 0xFF;
-	bool pmSaysLite = ((arm7_pmBacklight >> 4) & 0xF) == 4;
-	bool fwSaysLite = (arm7_consoleType == 0x20 || arm7_consoleType == 0x35 || arm7_consoleType == 0x63);
-	if (isRegularDS && pmSaysLite && fwSaysLite) isDSLite = true;
+	// DS Lite detection via the arm7's WiFi controller chip ID (W_ID): on a regular DS it reads
+	// 1440h on the original DS and C340h on the DS Lite. That ID lives in WiFi silicon, not in a
+	// reflashable firmware byte, so it can't be spoofed by cross-flashing. (A DSi/3DS also reports
+	// C340h, but those are already excluded by isRegularDS above.)
+	if (isRegularDS && arm7_wifiChipId == 0xC340) isDSLite = true;
 
 	// Detect RAM size and console model up front (3DS has 32MB of RAM).
 	// arm7 sends FIFO_USER_05 before the sync above, so this is ready here.


### PR DESCRIPTION
Uses the WiFi controller chip ID (W_ID, 4808000h) to tell a DS phat from a DS Lite: 1440h = phat, C340h = Lite. Unlike the firmware console-type byte it can't be reflashed, and unlike the power chip it isn't shared by late CPU-20 phats. Confirmed on hardware: phat 1440h, Lite C340h, DSi C340h. One thing I couldn't test: a CPU-20 phat should read 1440h, if anyone has one to confirm before merge, that's the only unverified case.